### PR TITLE
Update travis script to handle new installation procedure of osqp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -106,7 +106,7 @@ before_script:
   - sudo make install
 
   - cd $ROBOT_CODE
-  - git clone https://github.com/oxfordcontrol/osqp.git
+  - git clone --recursive https://github.com/oxfordcontrol/osqp.git
   - cd osqp
   - mkdir build
   - cd build


### PR DESCRIPTION
This fixes `travis` script by handling the new installation procedure of `osqp`+`qldld.`