### PR TITLE
added export of package so that source builds can be found directly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,3 +115,5 @@ if(BUILD_TESTING)
 endif()
 
 include(AddUninstallTarget)
+
+export(PACKAGE ${PROJECT_NAME})


### PR DESCRIPTION
I added the cmake export of the package so that source builds can be found directly without the new to specify OsqpEigen_DIR or install the package.