### PR TITLE
Use unique_ptr instead of raw pointer for OSQPWorkspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED 11)
 
 project(OsqpEigen
   LANGUAGES CXX
-  VERSION 0.5.102)
+  VERSION 0.5.103)
 
 # add GNU dirs
 include(GNUInstallDirs)

--- a/include/OsqpEigen/Solver.hpp
+++ b/include/OsqpEigen/Solver.hpp
@@ -31,7 +31,7 @@ namespace OsqpEigen
      */
     class Solver
     {
-        OSQPWorkspace *m_workspace;  /**< OSQPWorkspace struct. */
+        std::unique_ptr<OSQPWorkspace, std::function<void(OSQPWorkspace *)>> m_workspace;  /**< Pointer to OSQPWorkspace struct. */
         std::unique_ptr<OsqpEigen::Settings> m_settings; /**< Pointer to Settings class. */
         std::unique_ptr<OsqpEigen::Data> m_data; /**< Pointer to Data class. */
         Eigen::Matrix<c_float, Eigen::Dynamic ,1> m_primalVariables;
@@ -75,17 +75,18 @@ namespace OsqpEigen
         void selectUpperTriangularTriplets(const std::vector<Eigen::Triplet<T>> &fullMatrixTriplets,
                                            std::vector<Eigen::Triplet<T>> &upperTriangularMatrixTriplets) const;
 
+        /**
+         * Custom Deleter for the OSQPWorkspace. It is required to free the @ref m_workspace unique_ptr
+         * @param ptr raw pointer to the workspace
+         */
+        static void OSQPWorkspaceDeleter(OSQPWorkspace* ptr) noexcept;
+
     public:
 
         /**
          * Constructor.
          */
         Solver();
-
-        /**
-         * Deconstructor.
-         */
-        ~Solver();
 
         /**
          * Initialize the solver with the actual initial data and settings.

--- a/include/OsqpEigen/Solver.tpp
+++ b/include/OsqpEigen/Solver.tpp
@@ -49,7 +49,7 @@ bool OsqpEigen::Solver::updateHessianMatrix(const Eigen::SparseCompressedBase<De
     if(evaluateNewValues(m_oldHessianTriplet,  m_newUpperTriangularHessianTriplets,
                          m_hessianNewIndices, m_hessianNewValues)){
         if (m_hessianNewValues.size() > 0) {
-            if(osqp_update_P(m_workspace, m_hessianNewValues.data(), m_hessianNewIndices.data(), m_hessianNewIndices.size()) != 0){
+            if(osqp_update_P(m_workspace.get(), m_hessianNewValues.data(), m_hessianNewIndices.data(), m_hessianNewIndices.size()) != 0){
                 std::cerr << "[OsqpEigen::Solver::updateHessianMatrix] Unable to update hessian matrix."
                           << std::endl;
                 return false;
@@ -145,7 +145,7 @@ bool OsqpEigen::Solver::updateLinearConstraintsMatrix(const Eigen::SparseCompres
     if(evaluateNewValues(m_oldLinearConstraintsTriplet, m_newLinearConstraintsTriplet,
                          m_constraintsNewIndices, m_constraintsNewValues)){
         if (m_constraintsNewValues.size() > 0) {
-            if(osqp_update_A(m_workspace, m_constraintsNewValues.data(), m_constraintsNewIndices.data(), m_constraintsNewIndices.size()) != 0){
+            if(osqp_update_A(m_workspace.get(), m_constraintsNewValues.data(), m_constraintsNewIndices.data(), m_constraintsNewIndices.size()) != 0){
                 std::cerr << "[OsqpEigen::Solver::updateLinearConstraintsMatrix] Unable to update linear constraints matrix."
                           << std::endl;
                 return false;
@@ -224,7 +224,7 @@ bool OsqpEigen::Solver::setWarmStart(const Eigen::Matrix<T, n, 1> &primalVariabl
     m_primalVariables = primalVariable.template cast <c_float>();
     m_dualVariables = dualVariable.template cast <c_float>();
 
-    return (osqp_warm_start(m_workspace, m_primalVariables.data(), m_dualVariables.data()) == 0);
+    return (osqp_warm_start(m_workspace.get(), m_primalVariables.data(), m_dualVariables.data()) == 0);
 
 }
 
@@ -240,7 +240,7 @@ bool OsqpEigen::Solver::setPrimalVariable(const Eigen::Matrix<T, n, 1> &primalVa
 
     m_primalVariables = primalVariable.template cast <c_float>();
 
-    return (osqp_warm_start_x(m_workspace, m_primalVariables.data()) == 0);
+    return (osqp_warm_start_x(m_workspace.get(), m_primalVariables.data()) == 0);
 }
 
 
@@ -256,7 +256,7 @@ bool OsqpEigen::Solver::setDualVariable(const Eigen::Matrix<T, m, 1> &dualVariab
 
     m_dualVariables = dualVariable.template cast <c_float>();
 
-    return (osqp_warm_start_y(m_workspace, m_dualVariables.data()) == 0);
+    return (osqp_warm_start_y(m_workspace.get(), m_dualVariables.data()) == 0);
 }
 
 template<typename T, int n>
@@ -365,7 +365,7 @@ bool OsqpEigen::Solver::updateGradient(Eigen::Matrix<c_float, n, 1>& gradient)
     }
 
     // update the gradient vector
-    if(osqp_update_lin_cost(m_workspace, gradient.data())){
+    if(osqp_update_lin_cost(m_workspace.get(), gradient.data())){
         std::cerr << "[OsqpEigen::Solver::updateGradient] Error when the update gradient is called."
                   << std::endl;
         return false;
@@ -384,7 +384,7 @@ bool OsqpEigen::Solver::updateLowerBound(Eigen::Matrix<c_float, m, 1>& lowerBoun
     }
 
     // update the lower bound vector
-    if(osqp_update_lower_bound(m_workspace, lowerBound.data())){
+    if(osqp_update_lower_bound(m_workspace.get(), lowerBound.data())){
         std::cerr << "[OsqpEigen::Solver::updateLowerBound] Error when the update lower bound is called."
                   << std::endl;
         return false;
@@ -404,7 +404,7 @@ bool OsqpEigen::Solver::updateUpperBound(Eigen::Matrix<c_float, m, 1>& upperBoun
     }
 
     // update the upper bound vector
-    if(osqp_update_upper_bound(m_workspace, upperBound.data())){
+    if(osqp_update_upper_bound(m_workspace.get(), upperBound.data())){
         std::cerr << "[OsqpEigen::Solver::updateUpperBound] Error when the update upper bound is called."
                   << std::endl;
         return false;
@@ -432,7 +432,7 @@ bool OsqpEigen::Solver::updateBounds(Eigen::Matrix<c_float, m, 1>& lowerBound,
     }
 
     // update lower and upper constraints
-    if(osqp_update_bounds(m_workspace, lowerBound.data(), upperBound.data())){
+    if(osqp_update_bounds(m_workspace.get(), lowerBound.data(), upperBound.data())){
         std::cerr << "[OsqpEigen::Solver::updateBounds] Error when the update bounds is called."
                   << std::endl;
         return false;
@@ -480,7 +480,7 @@ bool OsqpEigen::Solver::updateHessianMatrix(const Eigen::SparseMatrix<T> &hessia
     if(evaluateNewValues(m_oldHessianTriplet,  m_newUpperTriangularHessianTriplets,
                          m_hessianNewIndices, m_hessianNewValues)){
         if (m_hessianNewValues.size() > 0) {
-            if(osqp_update_P(m_workspace, m_hessianNewValues.data(), m_hessianNewIndices.data(), m_hessianNewIndices.size()) != 0){
+            if(osqp_update_P(m_workspace.get(), m_hessianNewValues.data(), m_hessianNewIndices.data(), m_hessianNewIndices.size()) != 0){
                 std::cerr << "[OsqpEigen::Solver::updateHessianMatrix] Unable to update hessian matrix."
                           << std::endl;
                 return false;
@@ -576,7 +576,7 @@ bool OsqpEigen::Solver::updateLinearConstraintsMatrix(const Eigen::SparseMatrix<
     if(evaluateNewValues(m_oldLinearConstraintsTriplet, m_newLinearConstraintsTriplet,
                          m_constraintsNewIndices, m_constraintsNewValues)){
         if (m_constraintsNewValues.size() > 0) {
-            if(osqp_update_A(m_workspace, m_constraintsNewValues.data(), m_constraintsNewIndices.data(), m_constraintsNewIndices.size()) != 0){
+            if(osqp_update_A(m_workspace.get(), m_constraintsNewValues.data(), m_constraintsNewIndices.data(), m_constraintsNewIndices.size()) != 0){
                 std::cerr << "[OsqpEigen::Solver::updateLinearConstraintsMatrix] Unable to update linear constraints matrix."
                           << std::endl;
                 return false;


### PR DESCRIPTION
**The use of raw pointers is error-prone, makes the code unclear, and it is a cause of my headache.**   
Furthermore, in our specific case, using a raw pointer for `OSQPWorkspace` imposes us to implement a custom deleter (i.e. bye bye [Rule of zero](https://en.cppreference.com/w/cpp/language/rule_of_three)).
Breaking the **rule of zero** may bring to undesired behaviors (i.e. the move assignment/constructor operator are implicitly deleted  #37)

For the aforementioned problems, I decided to work on this PR. 

The `OSQPWorkspace` struct is now stored in an `unique_ptr`. However, deleting a `OSQPWorkspace` instance is not trivial. Indeed the [`osqp_clean()`](https://osqp.org/docs/interfaces/cc++#_CPPv412osqp_cleanupP13OSQPWorkspace) function has to be called. For this reason, I implemented a simple `unique_ptr` `deleter`.
I finally removed the custom destructor restoring the **rule of zero**. Now the move assignment/constructor member functions are not deleted and #37 is fixed.

Before opening the PR I ran the tests with valgrind 
```sh 
valgrind --tool=memcheck --leak-check=full --show-leak-kinds=all --track-origins=yes <test>
```
All the tests retun:
```
==19292== HEAP SUMMARY:
==19292== All heap blocks were freed -- no leaks are possible
==19292== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
So in therory no leaks are possible 