### PR TITLE
Check that all the settings are actually available.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(OsqpEigen
-  VERSION 0.6.101)
+  VERSION 0.6.102)
 
 # ouptut paths
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")

--- a/include/OsqpEigen/Settings.hpp
+++ b/include/OsqpEigen/Settings.hpp
@@ -170,6 +170,12 @@ namespace OsqpEigen
         void setWarmStart(const bool warmStart);
 
         /**
+        * Set the maximum number of seconds allowed to solve the problem.
+        * @param timeLimit is the time limit in seconds. If 0, then disabled.
+        */
+        void setTimeLimit(const double timeLimit);
+
+        /**
          * Get a pointer to Settings struct.
          * @return a const pointer to OSQPSettings struct.
          */

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -6,6 +6,9 @@
  */
 
 #include <OsqpEigen/Settings.hpp>
+#include <iostream>
+
+template <typename... Args> inline void unused(Args&&...) {}
 
 OsqpEigen::Settings::Settings()
 {
@@ -40,22 +43,47 @@ void OsqpEigen::Settings::setScaling(const int scaling)
 
 void OsqpEigen::Settings::setAdaptiveRho(const bool isRhoStepSizeAdactive)
 {
+# if EMBEDDED != 1
     m_settings->adaptive_rho = (c_int)isRhoStepSizeAdactive;
+# else
+    std::cerr<< "[OsqpEigen::Settings::setAdaptiveRho] OSPQ has been set to EMBEDDED, hence this setting is disabled." << std::endl;
+    unused(isRhoStepSizeAdactive);
+# endif
 }
 
 void OsqpEigen::Settings::setAdaptiveRhoInterval(const int rhoInterval)
 {
+# if EMBEDDED != 1
     m_settings->adaptive_rho_interval = (c_int)rhoInterval;
+# else
+    std::cerr<< "[OsqpEigen::Settings::setAdaptiveRhoInterval] OSPQ has been set to EMBEDDED, hence this setting is disabled." << std::endl;
+    unused(rhoInterval);
+# endif
 }
 
 void OsqpEigen::Settings::setAdaptiveRhoTolerance(const double adaptiveRhoTolerance)
 {
+# if EMBEDDED != 1
     m_settings->adaptive_rho_tolerance = (c_float)adaptiveRhoTolerance;
+# else
+    std::cerr<< "[OsqpEigen::Settings::setAdaptiveRhoTolerance] OSPQ has been set to EMBEDDED, hence this setting is disabled." << std::endl;
+    unused(adaptiveRhoTolerance);
+# endif
 }
 
 void OsqpEigen::Settings::setAdaptiveRhoFraction(const double adaptiveRhoFraction)
 {
+# if EMBEDDED != 1
+# ifdef PROFILING
     m_settings->adaptive_rho_fraction = (c_float)adaptiveRhoFraction;
+# else
+    std::cerr<< "[OsqpEigen::Settings::setAdaptiveRhoFraction] OSPQ has been set without PROFILING, hence this setting is disabled." << std::endl;
+    unused(adaptiveRhoFraction);
+# endif //ifdef PROFILING
+# else //# if EMBEDDED != 1
+    std::cerr<< "[OsqpEigen::Settings::setAdaptiveRhoFraction] OSPQ has been set to EMBEDDED, hence this setting is disabled." << std::endl;
+    unused(adaptiveRhoFraction);
+# endif //# if EMBEDDED != 1
 }
 void OsqpEigen::Settings::setMaxIteraction(const int maxIteration)
 {
@@ -94,22 +122,42 @@ void OsqpEigen::Settings::setLinearSystemSolver(const int linsysSolver)
 
 void OsqpEigen::Settings::setDelta(const double delta)
 {
+# ifndef EMBEDDED
     m_settings->delta = (c_float)delta;
+# else
+    std::cerr<< "[OsqpEigen::Settings::setDelta] OSPQ has been set to EMBEDDED, hence this setting is disabled." << std::endl;
+    unused(delta);
+# endif
 }
 
 void OsqpEigen::Settings::setPolish(const bool polish)
 {
+# ifndef EMBEDDED
     m_settings->polish = (c_int)polish;
+# else
+    std::cerr<< "[OsqpEigen::Settings::setPolish] OSPQ has been set to EMBEDDED, hence this setting is disabled." << std::endl;
+    unused(polish);
+# endif
 }
 
 void OsqpEigen::Settings::setPolishRefineIter(const int polishRefineIter)
 {
+# ifndef EMBEDDED
     m_settings->polish_refine_iter = (c_int)polishRefineIter;
+# else
+    std::cerr<< "[OsqpEigen::Settings::setPolishRefineIter] OSPQ has been set to EMBEDDED, hence this setting is disabled." << std::endl;
+    unused(polishRefineIter);
+# endif
 }
 
 void OsqpEigen::Settings::setVerbosity(const bool isVerbose)
 {
+#ifndef EMBEDDED
     m_settings->verbose = (c_int)isVerbose;
+#else
+    std::cerr<< "[OsqpEigen::Settings::setVerbosity] OSPQ has been set to EMBEDDED, hence this setting is disabled." << std::endl;
+    unused(isVerbose);
+#endif
 }
 
 void OsqpEigen::Settings::setScaledTerimination(const bool scaledTermination)
@@ -125,6 +173,16 @@ void OsqpEigen::Settings::setCheckTermination(const int checkTermination)
 void OsqpEigen::Settings::setWarmStart(const bool warmStart)
 {
     m_settings->warm_start = (c_int)warmStart;
+}
+
+void OsqpEigen::Settings::setTimeLimit(const double timeLimit)
+{
+# ifdef PROFILING
+    m_settings->time_limit = (c_float)timeLimit;
+# else
+    std::cerr<< "[OsqpEigen::Settings::setTimeLimit] OSPQ has been set without PROFILING, hence this setting is disabled." << std::endl;
+    unused(timeLimit);
+# endif
 }
 
 OSQPSettings* const & OsqpEigen::Settings::getSettings() const


### PR DESCRIPTION
As it can be noticed from the [``osqp`` code](https://github.com/oxfordcontrol/osqp/blob/6fb6db97a33a81d40a006ffc8a4213d7599bb656/include/types.h#L125-L176) some settings may not be available depending on the specific Cmake settings. With this PR we copy the same checks adding an error message in case some settings are not available. 

I also added the ``time_limit`` setting (see https://github.com/robotology/osqp-eigen/issues/38).

~In draft since I have to bump the version number, but there are other PR open at the moment.~
