### PR TITLE
Using nullptr to avoid static assert on test names.

### DIFF
--- a/tests/MPCTest.cpp
+++ b/tests/MPCTest.cpp
@@ -213,7 +213,7 @@ double getErrorNorm(const Eigen::Matrix<double, 12, 1> &x,
 }
 
 
-TEST(MPCTest,)
+TEST(MPCTest, nullptr)
 {
     // open the ofstream
     std::ofstream dataStream;

--- a/tests/MPCUpdateMatricesTest.cpp
+++ b/tests/MPCUpdateMatricesTest.cpp
@@ -183,7 +183,7 @@ void updateConstraintVectors(const Eigen::Matrix<double, 2, 1> &x0,
     upperBound.block(0,0,2,1) = -x0;
 }
 
-TEST(MPCTest,)
+TEST(MPCTest, nullptr)
 {
     // open the ofstream
     std::ofstream dataStream;

--- a/tests/QPTest.cpp
+++ b/tests/QPTest.cpp
@@ -10,7 +10,7 @@
 
 #include <OsqpEigen/OsqpEigen.h>
 
-TEST(QPProblem, )
+TEST(QPProblem, nullptr)
 {
     Eigen::Matrix2d H;
     H << 4, 1,


### PR DESCRIPTION
Fixes #55 

I got this fix from https://github.com/monero-project/monero/pull/6346/files