### PR TITLE
Check the initialization of the solver went fine while updating hessian and constraint matrix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.5)
 
 project(OsqpEigen
-  VERSION 0.6.103)
+  VERSION 0.6.104)
 
 # ouptut paths
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")

--- a/include/OsqpEigen/Solver.tpp
+++ b/include/OsqpEigen/Solver.tpp
@@ -89,7 +89,11 @@ bool OsqpEigen::Solver::updateHessianMatrix(const Eigen::SparseCompressedBase<De
         clearSolver();
 
         // initialize a new solver
-        initSolver();
+        if(!initSolver()){
+            std::cerr << "[OsqpEigen::Solver::updateHessianMatrix] Unable to Initialize the solver."
+                      << std::endl;
+            return false;
+        }
 
         // set the old primal and dual variables
         if(!setPrimalVariable(m_primalVariables)){
@@ -184,8 +188,11 @@ bool OsqpEigen::Solver::updateLinearConstraintsMatrix(const Eigen::SparseCompres
         // clear the old solver
         clearSolver();
 
-        // initialize a new solver
-        initSolver();
+        if(!initSolver()){
+            std::cerr << "[OsqpEigen::Solver::updateLinearConstraintsMatrix] Unable to Initialize the solver."
+                      << std::endl;
+            return false;
+        }
 
         // set the old primal and dual variables
         if(!setPrimalVariable(m_primalVariables)){


### PR DESCRIPTION
I noticed that there are cases in which the solver initialization while updating the hessian and the constraint matrices throw an error. I.e. The new hessian matrix is not SDP. In case of problems, without checking the return value of `initSolver()`, the code crashes with segmentation fault in `setPrimalVariable()`.
This PR fixes the aforementioned problem. 