### PR TITLE
[Solver.tpp] add warning message to updateHessianMatrix and updateLinearConstraintsMatrix for RowMajor

### DIFF
--- a/include/OsqpEigen/Solver.tpp
+++ b/include/OsqpEigen/Solver.tpp
@@ -25,6 +25,11 @@ bool OsqpEigen::Solver::updateHessianMatrix(const Eigen::SparseCompressedBase<De
         return false;
     }
 
+    if(hessianMatrix.IsRowMajor){
+        std::cerr << "[OsqpEigen::Solver::updateHessianMatrix] The hessian matrix has to be ColMajor"
+                  << std::endl;
+        return false;
+    }
 
     // evaluate the triplets from old and new hessian sparse matrices
     if(!OsqpEigen::SparseMatrixHelper::osqpSparseMatrixToTriplets(m_workspace->data->P,
@@ -123,6 +128,12 @@ bool OsqpEigen::Solver::updateLinearConstraintsMatrix(const Eigen::SparseCompres
     if(((c_int)linearConstraintsMatrix.rows() != m_workspace->data->m)||
        ((c_int)linearConstraintsMatrix.cols() != m_workspace->data->n)){
         std::cerr << "[OsqpEigen::Solver::updateLinearConstraintsMatrix] The constraints matrix has to be a mxn matrix"
+                  << std::endl;
+        return false;
+    }
+
+    if(linearConstraintsMatrix.IsRowMajor){
+        std::cerr << "[OsqpEigen::Solver::updateLinearConstraintsMatrix] The constraints matrix has to be ColMajor"
                   << std::endl;
         return false;
     }


### PR DESCRIPTION
Hello. I am a user of  OsqpEigen.

`OsqpEigen::Solver::updateHessianMatrix` and `OsqpEigen::Solver::updateLinearConstraintsMatrix` do not support RowMajor matrix
because `OsqpEigen::SparseMatrixHelper::eigenSparseMatrixToTriplets` does not support RowMajor matrix.

I have added warning message to inform users of this.