### PR TITLE
GitHub Action: Bump the webfactory/ssh-agent to v0.4.1

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-      - uses: webfactory/ssh-agent@v0.3.0
+      - uses: webfactory/ssh-agent@v0.4.1
         with:
           ssh-private-key: ${{ secrets.SSH_PRIVATE_GH_PAGES }}
       - name: Dependencies


### PR DESCRIPTION
This new release addresses https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/