### PR TITLE
Bump the required CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CopyPolicy: Released under the terms of the LGPLv2.1 or later
 
 # Set cmake mimimun version
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.8)
 
 project(OsqpEigen
   VERSION 0.6.3)


### PR DESCRIPTION
The ``cxx_std_14`` feature has been added starting from the 3.8 version. See https://cmake.org/cmake/help/v3.8/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html#prop_gbl:CMAKE_CXX_KNOWN_FEATURES vs https://cmake.org/cmake/help/v3.5/prop_gbl/CMAKE_CXX_KNOWN_FEATURES.html#prop_gbl:CMAKE_CXX_KNOWN_FEATURES