### PR TITLE
Add SIMD option to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,23 @@ endif()
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 option(BUILD_SHARED_LIBS "Build libraries as shared as opposed to static" ON)
+option(ENABLE_SIMD "Build with all SIMD instructions on the current local machine" OFF)
+
+function(add_simd TARGET)
+  if(ENABLE_SIMD)
+    if(CMAKE_COMPILER_IS_GNUCXX)
+      execute_process(
+        COMMAND ${CMAKE_CXX_COMPILER} -dumpfullversion -dumpversion OUTPUT_VARIABLE GCC_VERSION)
+      set(CXX_COMPILER_VERSION ${GCC_VERSION})
+      target_compile_options(${TARGET} PUBLIC -march=native)
+      if(GCC_VERSION VERSION_GREATER 7.0)
+        target_compile_options(${TARGET} PUBLIC -faligned-new)
+      endif()
+    elseif("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
+      target_compile_options(${TARGET} PUBLIC -march=native -faligned-new)
+    endif()
+  endif()
+endfunction()
 
 # Disable C and C++ compiler extensions.
 # C/CXX_EXTENSIONS are ON by default to allow the compilers to use extended
@@ -100,6 +117,9 @@ target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CM
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC osqp::osqp Eigen3::Eigen)
+
+# Add SIMD if enabled
+add_simd(${LIBRARY_TARGET_NAME})
 
 add_library(OsqpEigen::OsqpEigen ALIAS OsqpEigen)
 

--- a/cmake/AddOsqpEigenUnitTest.cmake
+++ b/cmake/AddOsqpEigenUnitTest.cmake
@@ -31,6 +31,7 @@ if (OSQPEIGEN_COMPILE_tests)
     configure_file(cmake/Catch2Main.cpp.in ${CMAKE_BINARY_DIR}/Testing/Catch2Main.cpp)
     add_library(CatchTestMain ${CMAKE_BINARY_DIR}/Testing/Catch2Main.cpp)
     target_link_libraries(CatchTestMain PUBLIC Catch2::Catch2)
+    add_simd(CatchTestMain)
 endif()
 
 
@@ -64,8 +65,11 @@ function(add_osqpeigen_test)
       add_test(NAME ${targetname} COMMAND ${targetname})
       target_compile_definitions(${targetname} PRIVATE ${${prefix}_COMPILE_DEFINITIONS})
 
+      add_simd(${targetname})
+
       if(OSQPEIGEN_RUN_Valgrind_tests)
         add_test(NAME memcheck_${targetname} COMMAND ${MEMCHECK_COMMAND_COMPLETE} $<TARGET_FILE:${targetname}>)
+        add_simd(memcheck_${targetname})
       endif()
 
     endif()


### PR DESCRIPTION
In many of my projects, I am using SIMD flags with Eigen for improved performance (e.g., march=native). This PR adds an option to enable this in gcc and clang compilers. Feel free to add MSVC or ICC if needed. By default this option is OFF as native flags can cause many issues. Tested on an ArchLinux machine and works like charm with and without the flag (both the lib and the tests).