### PR TITLE
Handle osqp errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 cmake_minimum_required(VERSION 3.8)
 
 project(OsqpEigen
-  VERSION 0.6.4)
+  VERSION 0.6.4.100)
 
 # ouptut paths
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}")

--- a/include/OsqpEigen/Constants.hpp
+++ b/include/OsqpEigen/Constants.hpp
@@ -16,7 +16,44 @@
  */
 namespace OsqpEigen
 {
-    const c_float INFTY = OSQP_INFTY; /**< Infinity constant. */
+    constexpr c_float INFTY = OSQP_INFTY; /**< Infinity constant. */
+
+    /**
+     * Status of the solver
+     */
+    enum class Status : int
+    {
+        DualInfeasibleInaccurate = OSQP_DUAL_INFEASIBLE_INACCURATE,
+        PrimalInfeasibleInaccurate = OSQP_PRIMAL_INFEASIBLE_INACCURATE,
+        SolvedInaccurate = OSQP_SOLVED_INACCURATE,
+        Solved = OSQP_SOLVED,
+        MaxIterReached = OSQP_MAX_ITER_REACHED,
+        PrimalInfeasible = OSQP_PRIMAL_INFEASIBLE,
+        DualInfeasible = OSQP_DUAL_INFEASIBLE,
+        Sigint = OSQP_SIGINT,
+# ifdef PROFILING
+        TimeLimitReached = OSQP_TIME_LIMIT_REACHED,
+# endif // ifdef PROFILING
+        NonCvx = OSQP_NON_CVX,
+        Unsolved = OSQP_UNSOLVED
+    };
+
+
+    /**
+     * Error status of the Solver
+     */
+    enum class ErrorExitFlag : int
+    {
+        NoError = 0,
+        DataValidationError = OSQP_DATA_VALIDATION_ERROR,
+        SettingsValidationError = OSQP_SETTINGS_VALIDATION_ERROR,
+        LinsysSolverLoadError = OSQP_LINSYS_SOLVER_LOAD_ERROR,
+        LinsysSolverInitError = OSQP_LINSYS_SOLVER_INIT_ERROR,
+        NonCvxError = OSQP_NONCVX_ERROR,
+        MemAllocError = OSQP_MEM_ALLOC_ERROR,
+        WorkspaceNotInitError = OSQP_WORKSPACE_NOT_INIT_ERROR
+    };
+
 }
 
 #endif

--- a/include/OsqpEigen/Solver.hpp
+++ b/include/OsqpEigen/Solver.hpp
@@ -116,7 +116,20 @@ namespace OsqpEigen
          * Solve the QP optimization problem.
          * @return true/false in case of success/failure.
          */
+        [[deprecated("Use solveProblem() instead.")]]
         bool solve();
+
+        /**
+         * Solve the QP optimization problem.
+         * @return the error exit flag
+         */
+        OsqpEigen::ErrorExitFlag solveProblem();
+
+        /**
+         * Get the status of the solver
+         * @return The inner solver status
+         */
+        OsqpEigen::Status getStatus() const;
 
         /**
          * Get the optimization problem solution.

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -127,28 +127,37 @@ void OsqpEigen::Solver::clearSolver()
 
 bool OsqpEigen::Solver::solve()
 {
-    if(!m_isSolverInitialized){
-        debugStream() << "[OsqpEigen::Solver::solve] The solve has not been initialized yet. "
-                  << "Please call initSolver() method."
-                  << std::endl;
-        return false;
-    }
-
-    if(osqp_solve(m_workspace.get()) != 0){
+    if (this->solveProblem() != OsqpEigen::ErrorExitFlag::NoError) {
         debugStream() << "[OsqpEigen::Solver::solve] Unable to solve the problem."
-                  << std::endl;
+                      << std::endl;
         return false;
     }
 
     // check if the solution is feasible
-    if(m_workspace->info->status_val != OSQP_SOLVED)
-    {
+    if(this->getStatus() != OsqpEigen::Status::Solved) {
         debugStream() << "[OsqpEigen::Solver::solve] The solution is unfeasible."
-                  << std::endl;
+                      << std::endl;
         return false;
     }
 
     return true;
+}
+
+OsqpEigen::Status OsqpEigen::Solver::getStatus() const
+{
+    return static_cast<OsqpEigen::Status>(m_workspace->info->status_val);
+}
+
+OsqpEigen::ErrorExitFlag OsqpEigen::Solver::solveProblem()
+{
+    if(!m_isSolverInitialized){
+        debugStream() << "[OsqpEigen::Solver::solveProblem] The solve has not been initialized yet. "
+                  << "Please call initSolver() method."
+                  << std::endl;
+        return OsqpEigen::ErrorExitFlag::WorkspaceNotInitError;
+    }
+
+    return static_cast<OsqpEigen::ErrorExitFlag>(osqp_solve(m_workspace.get()));
 }
 
 const Eigen::VectorXd &OsqpEigen::Solver::getSolution()


### PR DESCRIPTION
This PR introduces `Status` and `ErrorExitFlag` enum class that replicates the content of https://osqp.org/docs/interfaces/status_values.html

Furthermore, I implemented:
1. `OsqpEigen::Solver::solveProblem`: this function will substitute `OsqpEigen::Solver::solve` and it will return the `ErrorExitFlag`
2. `OsqpEigen::Solver::getStatus` to get the internal state of `osqp` solver. 

This closes #110 