### PR TITLE
Import AddUninstallTarget.cmake from YCM v0.14.1 to fix compilation with ninja

### DIFF
--- a/cmake/AddUninstallTarget.cmake
+++ b/cmake/AddUninstallTarget.cmake
@@ -1,41 +1,31 @@
-#.rst:
-# AddUninstallTarget
-# ------------------
-#
-# Add the "uninstall" target for your project::
-#
-#   include(AddUninstallTarget)
-#
-#
-# will create a file ``cmake_uninstall.cmake`` in the build directory and add a
-# custom target ``uninstall`` (or ``UNINSTALL`` on Visual Studio and Xcode) that
-# will remove the files installed by your package (using
-# ``install_manifest.txt``).
-# See also
-# https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake
-#
-# The :module:`AddUninstallTarget` module must be included in your main
-# ``CMakeLists.txt``. If included in a subdirectory it does nothing.
-# This allows you to use it safely in your main ``CMakeLists.txt`` and include
-# your project using ``add_subdirectory`` (for example when using it with
-# :cmake:module:`FetchContent`).
-#
-# If the ``uninstall`` target already exists, the module does nothing.
+# SPDX-FileCopyrightText: 2012-2021 Istituto Italiano di Tecnologia (IIT)
+# SPDX-FileCopyrightText: 2008-2013 Kitware Inc.
+# SPDX-License-Identifier: BSD-3-Clause
 
-#=============================================================================
-# Copyright 2008-2013 Kitware, Inc.
-# Copyright 2013 Istituto Italiano di Tecnologia (IIT)
-#   Authors: Daniele E. Domenichelli <daniele.domenichelli@iit.it>
-#
-# Distributed under the OSI-approved BSD License (the "License");
-# see accompanying file Copyright.txt for details.
-#
-# This software is distributed WITHOUT ANY WARRANTY; without even the
-# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-# See the License for more information.
-#=============================================================================
-# (To distribute this file outside of CMake, substitute the full
-#  License text for the above reference.)
+#[=======================================================================[.rst:
+AddUninstallTarget
+------------------
+
+Add the "uninstall" target for your project::
+
+  include(AddUninstallTarget)
+
+
+will create a file ``cmake_uninstall.cmake`` in the build directory and add a
+custom target ``uninstall`` (or ``UNINSTALL`` on Visual Studio and Xcode) that
+will remove the files installed by your package (using
+``install_manifest.txt``).
+See also
+https://gitlab.kitware.com/cmake/community/wikis/FAQ#can-i-do-make-uninstall-with-cmake
+
+The :module:`AddUninstallTarget` module must be included in your main
+``CMakeLists.txt``. If included in a subdirectory it does nothing.
+This allows you to use it safely in your main ``CMakeLists.txt`` and include
+your project using ``add_subdirectory`` (for example when using it with
+:cmake:module:`FetchContent`).
+
+If the ``uninstall`` target already exists, the module does nothing.
+#]=======================================================================]
 
 
 # AddUninstallTarget works only when included in the main CMakeLists.txt
@@ -57,13 +47,14 @@ if(TARGET ${_uninstall})
 endif()
 
 
-set(_filename "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
+set(_filename cmake_uninstall.cmake)
 
-file(WRITE ${_filename}
+file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/${_filename}"
 "if(NOT EXISTS \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\")
   message(WARNING \"Cannot find install manifest: \\\"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\\\"\")
   return()
 endif()
+
 file(READ \"${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt\" files)
 string(STRIP \"\${files}\" files)
 string(REGEX REPLACE \"\\n\" \";\" files \"\${files}\")
@@ -84,7 +75,18 @@ foreach(file \${files})
 endforeach(file)
 ")
 
+set(_desc "Uninstall the project...")
+if(CMAKE_GENERATOR STREQUAL "Unix Makefiles")
+  set(_comment COMMAND \$\(CMAKE_COMMAND\) -E cmake_echo_color --switch=$\(COLOR\) --cyan "${_desc}")
+else()
+  set(_comment COMMENT "${_desc}")
+endif()
 add_custom_target(${_uninstall}
-                  COMMAND "${CMAKE_COMMAND}" -E cmake_echo_color --switch=$\(COLOR\) --cyan "Uninstall the project..."
-                  COMMAND "${CMAKE_COMMAND}" -P "${_filename}")
+                  ${_comment}
+                  COMMAND ${CMAKE_COMMAND} -P ${_filename}
+                  USES_TERMINAL
+                  BYPRODUCTS uninstall_byproduct
+                  WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}")
+set_property(SOURCE uninstall_byproduct PROPERTY SYMBOLIC 1)
+
 set_property(TARGET ${_uninstall} PROPERTY FOLDER "CMakePredefinedTargets")


### PR DESCRIPTION
From https://github.com/robotology/ycm/blob/v0.14.1/modules/AddUninstallTarget.cmake

The osqp-eigen PR https://github.com/robotology/osqp-eigen/pull/117 introduced a ninja-related regression as it ported from YCM the PR https://github.com/robotology/ycm/issues/169  without porting the related commit https://github.com/robotology/ycm/commit/f2c61b1b9f5b2a7935bf79d1d43a68a218225804 that is a fix for https://github.com/robotology/ycm/issues/240 . To avoid the problem, I just import the module from the latest YCM release.

Fix https://github.com/robotology/robotology-superbuild/issues/1153 .