### PR TITLE
Missing include when compiling with MSVC 2022

### DIFF
--- a/include/OsqpEigen/SparseMatrixHelper.tpp
+++ b/include/OsqpEigen/SparseMatrixHelper.tpp
@@ -5,6 +5,7 @@
  * @date 2018
  */
 
+#include <cassert>
 #include <OsqpEigen/Debug.hpp>
 
 template<typename Derived>


### PR DESCRIPTION
I made a small fix for a missing include when compiling with MSVC 2022 (at line 56 there is `assert(innerOsqpPosition == numberOfNonZeroCoeff);` which requires `<cassert>` header).