### PR TITLE
Make the code compatible with OSQP v1.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ set(${LIBRARY_TARGET_NAME}_HDR
   include/OsqpEigen/Settings.hpp
   include/OsqpEigen/Solver.hpp
   include/OsqpEigen/Solver.tpp
+  include/OsqpEigen/Compat.hpp
   include/OsqpEigen/Debug.hpp)
 
 add_library(${LIBRARY_TARGET_NAME} ${${LIBRARY_TARGET_NAME}_SRC} ${${LIBRARY_TARGET_NAME}_HDR})
@@ -110,6 +111,9 @@ target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CM
   "$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>")
 
 target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC osqp::osqp Eigen3::Eigen)
+if(OSQP_IS_V1)
+  target_compile_definitions(${LIBRARY_TARGET_NAME} PUBLIC OSQP_EIGEN_OSQP_IS_V1)
+endif()
 
 add_library(OsqpEigen::OsqpEigen ALIAS OsqpEigen)
 

--- a/cmake/OsqpEigenDependencies.cmake
+++ b/cmake/OsqpEigenDependencies.cmake
@@ -11,6 +11,7 @@ include(OsqpEigenFindOptionalDependencies)
 ## Required Dependencies
 find_package(Eigen3 3.2.92 REQUIRED)
 find_package(osqp REQUIRED)
+try_compile(OSQP_IS_V1 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp.cpp LINK_LIBRARIES osqp::osqp)
 
 #---------------------------------------------
 ## Optional Dependencies

--- a/cmake/try-osqp.cpp
+++ b/cmake/try-osqp.cpp
@@ -1,0 +1,7 @@
+// This file is only available on OSQP >= 1.0.0
+#include <osqp_api_functions.h>
+
+int main()
+{
+  return 0;
+}

--- a/include/OsqpEigen/Compat.hpp
+++ b/include/OsqpEigen/Compat.hpp
@@ -1,0 +1,51 @@
+/**
+ * @file SparseMatrixHelper.hpp
+ * @author Pierre Gergondet
+ * @copyright  Released under the terms of the BSD 3-Clause License
+ * @date 2023
+ */
+
+#ifndef OSQP_EIGEN_COMPAT_HPP
+#define OSQP_EIGEN_COMPAT_HPP
+
+// OSQP
+#include <osqp.h>
+
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+
+// Re-use the same name in the global namespace as the old versions of OSQP
+using c_int = OSQPInt;
+using c_float = OSQPFloat;
+using csc = OSQPCscMatrix;
+
+// Those symbols are available in the library but hidden from the public API
+extern "C"
+{
+  extern OSQPCscMatrix * csc_spalloc(c_int m, c_int n, c_int nzmax, c_int values, c_int triplet);
+  extern void csc_spfree(OSQPCscMatrix * A);
+}
+
+#  ifndef OSQP_CUSTOM_MEMORY
+#    define c_malloc malloc
+#    define c_free free
+#  endif
+
+namespace OsqpEigen
+{
+
+struct OSQPData
+{
+  OSQPInt n; ///< number of variables n
+  OSQPInt m; ///< number of constraints m
+  OSQPCscMatrix * P; ///< the upper triangular part of the quadratic objective matrix P (size n x n).
+  OSQPCscMatrix * A; ///< linear constraints matrix A (size m x n)
+  OSQPFloat * q; ///< dense array for linear part of objective function (size n)
+  OSQPFloat * l; ///< dense array for lower bound (size m)
+  OSQPFloat * u; ///< dense array for upper bound (size m)
+};
+
+} // namespace OsqpEigen
+
+#endif
+
+#endif

--- a/include/OsqpEigen/Constants.hpp
+++ b/include/OsqpEigen/Constants.hpp
@@ -8,8 +8,7 @@
 #ifndef OSQPEIGEN_CONSTANTS_HPP
 #define OSQPEIGEN_CONSTANTS_HPP
 
-// osqp
-#include <osqp.h>
+#include <OsqpEigen/Compat.hpp>
 
 /**
  * OsqpEigen namespace.
@@ -47,7 +46,11 @@ namespace OsqpEigen
         NoError = 0,
         DataValidationError = OSQP_DATA_VALIDATION_ERROR,
         SettingsValidationError = OSQP_SETTINGS_VALIDATION_ERROR,
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+        LinsysSolverLoadError = OSQP_ALGEBRA_LOAD_ERROR,
+#else
         LinsysSolverLoadError = OSQP_LINSYS_SOLVER_LOAD_ERROR,
+#endif
         LinsysSolverInitError = OSQP_LINSYS_SOLVER_INIT_ERROR,
         NonCvxError = OSQP_NONCVX_ERROR,
         MemAllocError = OSQP_MEM_ALLOC_ERROR,

--- a/include/OsqpEigen/Solver.hpp
+++ b/include/OsqpEigen/Solver.hpp
@@ -104,7 +104,7 @@ namespace OsqpEigen
 #ifdef OSQP_EIGEN_OSQP_IS_V1
           return m_solver->info;
 #else
-          return m_workspace->Info;
+          return m_workspace->info;
 #endif
         }
 

--- a/include/OsqpEigen/SparseMatrixHelper.hpp
+++ b/include/OsqpEigen/SparseMatrixHelper.hpp
@@ -14,8 +14,7 @@
 // eigen
 #include <Eigen/Sparse>
 
-// OSQP
-#include <osqp.h>
+#include <OsqpEigen/Compat.hpp>
 
 /**
  * OsqpEigen namespace.

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -80,7 +80,7 @@ void OsqpEigen::Data::setNumberOfConstraints(int m)
     m_data->m = m;
 }
 
-OSQPData* const & OsqpEigen::Data::getData() const
+OsqpEigen::OSQPData* const & OsqpEigen::Data::getData() const
 {
     return m_data;
 }

--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -80,7 +80,7 @@ void OsqpEigen::Data::setNumberOfConstraints(int m)
     m_data->m = m;
 }
 
-OsqpEigen::OSQPData* const & OsqpEigen::Data::getData() const
+auto OsqpEigen::Data::getData() const -> OSQPData*const &
 {
     return m_data;
 }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -5,8 +5,9 @@
  * @date 2018
  */
 
-#include <OsqpEigen/Settings.hpp>
+#include <OsqpEigen/Compat.hpp>
 #include <OsqpEigen/Debug.hpp>
+#include <OsqpEigen/Settings.hpp>
 #include <iostream>
 
 template <typename... Args> inline void unused(Args&&...) {}
@@ -134,7 +135,11 @@ void OsqpEigen::Settings::setAlpha(const double alpha)
 
 void OsqpEigen::Settings::setLinearSystemSolver(const int linsysSolver)
 {
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+    m_settings->linsys_solver = (osqp_linsys_solver_type)linsysSolver;
+#else
     m_settings->linsys_solver = (linsys_solver_type)linsysSolver;
+#endif
 }
 
 void OsqpEigen::Settings::setDelta(const double delta)
@@ -149,12 +154,16 @@ void OsqpEigen::Settings::setDelta(const double delta)
 
 void OsqpEigen::Settings::setPolish(const bool polish)
 {
-# ifndef EMBEDDED
+#ifndef EMBEDDED
+#  ifdef OSQP_EIGEN_OSQP_IS_V1
+    m_settings->polishing = (c_int)polish;
+#  else
     m_settings->polish = (c_int)polish;
-# else
-    debugStream()<< "[OsqpEigen::Settings::setPolish] OSPQ has been set to EMBEDDED, hence this setting is disabled." << std::endl;
+#  endif
+#else
+  debugStream() << "[OsqpEigen::Settings::setPolish] OSPQ has been set to EMBEDDED, hence this setting is disabled."  << std::endl;
     unused(polish);
-# endif
+#endif
 }
 
 void OsqpEigen::Settings::setPolishRefineIter(const int polishRefineIter)
@@ -189,7 +198,11 @@ void OsqpEigen::Settings::setCheckTermination(const int checkTermination)
 
 void OsqpEigen::Settings::setWarmStart(const bool warmStart)
 {
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+    m_settings->warm_starting = (c_int)warmStart;
+#else
     m_settings->warm_start = (c_int)warmStart;
+#endif
 }
 
 void OsqpEigen::Settings::setTimeLimit(const double timeLimit)

--- a/src/Solver.cpp
+++ b/src/Solver.cpp
@@ -11,15 +11,22 @@
 #include <OsqpEigen/Solver.hpp>
 #include <OsqpEigen/Debug.hpp>
 
-void OsqpEigen::Solver::OSQPWorkspaceDeleter(OSQPWorkspace* ptr) noexcept
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+void OsqpEigen::Solver::OSQPSolverDeleter(OSQPSolver * ptr) noexcept
+#else
+void OsqpEigen::Solver::OSQPWorkspaceDeleter(OSQPWorkspace * ptr) noexcept
+#endif
 {
     if(ptr != nullptr)
         osqp_cleanup(ptr);
 }
 
-OsqpEigen::Solver::Solver()
-    : m_isSolverInitialized(false)
-    , m_workspace{nullptr, Solver::OSQPWorkspaceDeleter}
+OsqpEigen::Solver::Solver() : m_isSolverInitialized(false),
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+    m_solver{nullptr, Solver::OSQPSolverDeleter}
+#else
+    m_workspace{nullptr, Solver::OSQPWorkspaceDeleter}
+#endif
 {
     m_settings = std::make_unique<OsqpEigen::Settings>();
     m_data = std::make_unique<OsqpEigen::Data>();
@@ -27,39 +34,41 @@ OsqpEigen::Solver::Solver()
 
 bool OsqpEigen::Solver::clearSolverVariables()
 {
-    if(!m_isSolverInitialized){
-        debugStream() << "[OsqpEigen::Solver::clearSolverVariables] Unable to clear the solver variables. "
-                  << "Are you sure that the solver is initialized?"
-                  << std::endl;
-        return false;
+    if(!m_isSolverInitialized)
+    {
+      debugStream() << "[OsqpEigen::Solver::clearSolverVariables] Unable to clear the solver variables. "
+                    << "Are you sure that the solver is initialized?" << std::endl;
+      return false;
     }
 
-    for(int i = 0; i < m_workspace->data->n; i++){
-        m_workspace->x[i] = 0;
-        m_workspace->x_prev[i] = 0;
+#ifndef OSQP_EIGEN_OSQP_IS_V1
+    for(int i = 0; i < getData()->n; i++)
+    {
+      m_workspace->x[i] = 0;
+      m_workspace->x_prev[i] = 0;
 
-        m_workspace->Px[i] = 0;
-        m_workspace->Aty[i] = 0;
-        m_workspace->Atdelta_y[i] = 0;
+      m_workspace->Px[i] = 0;
+      m_workspace->Aty[i] = 0;
+      m_workspace->Atdelta_y[i] = 0;
 
-        m_workspace->delta_x[i] = 0;
-        m_workspace->Pdelta_x[i] = 0;
+      m_workspace->delta_x[i] = 0;
+      m_workspace->Pdelta_x[i] = 0;
     }
 
-    for(int i = 0; i < m_workspace->data->m; i++){
-        m_workspace->z[i] = 0;
-        m_workspace->z_prev[i] = 0;
-        m_workspace->y[i] = 0;
+    for(int i = 0; i < getData()->m; i++)
+    {
+      m_workspace->z[i] = 0;
+      m_workspace->z_prev[i] = 0;
+      m_workspace->y[i] = 0;
 
-        m_workspace->Ax[i] = 0;
-        m_workspace->delta_y[i] = 0;
+      m_workspace->Ax[i] = 0;
+      m_workspace->delta_y[i] = 0;
 
-        m_workspace->Adelta_x[i] = 0;
+      m_workspace->Adelta_x[i] = 0;
     }
 
-    for(int i = 0; i < m_workspace->data->n + m_workspace->data->m; i++){
-        m_workspace->xz_tilde[i] = 0;
-    }
+    for(int i = 0; i < getData()->n + getData()->m; i++) { m_workspace->xz_tilde[i] = 0; }
+#endif
 
     return true;
 }
@@ -98,6 +107,18 @@ bool OsqpEigen::Solver::initSolver()
         }
     }
 
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+    OSQPSolver * solver;
+    auto data = m_data->getData();
+    if(osqp_setup(&solver, data->P, data->q, data->A, data->l, data->u, data->m, data->n, m_settings->getSettings()) != 0)
+    {
+        debugStream() << "[OsqpEigen::Solver::initSolver] Unable to setup the workspace."
+                  << std::endl;
+        return false;
+    }
+
+    m_solver.reset(solver);
+#else
     OSQPWorkspace* workspace;
     if(osqp_setup(&workspace, m_data->getData(),
                   m_settings->getSettings()) != 0 ){
@@ -107,6 +128,7 @@ bool OsqpEigen::Solver::initSolver()
     }
 
     m_workspace.reset(workspace);
+#endif
 
     m_isSolverInitialized = true;
     return true;
@@ -120,7 +142,11 @@ bool OsqpEigen::Solver::isInitialized()
 void OsqpEigen::Solver::clearSolver()
 {
     if(m_isSolverInitialized){
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+        m_solver.reset();
+#else
         m_workspace.reset();
+#endif
         m_isSolverInitialized = false;
     }
 }
@@ -145,12 +171,12 @@ bool OsqpEigen::Solver::solve()
 
 OsqpEigen::Status OsqpEigen::Solver::getStatus() const
 {
-    return static_cast<OsqpEigen::Status>(m_workspace->info->status_val);
+    return static_cast<OsqpEigen::Status>(getInfo()->status_val);
 }
 
 const c_float OsqpEigen::Solver::getObjValue() const
 {
-    return m_workspace->info->obj_val;
+    return getInfo()->obj_val;
 }
 
 OsqpEigen::ErrorExitFlag OsqpEigen::Solver::solveProblem()
@@ -162,14 +188,18 @@ OsqpEigen::ErrorExitFlag OsqpEigen::Solver::solveProblem()
         return OsqpEigen::ErrorExitFlag::WorkspaceNotInitError;
     }
 
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+    return static_cast<OsqpEigen::ErrorExitFlag>(osqp_solve(m_solver.get()));
+#else
     return static_cast<OsqpEigen::ErrorExitFlag>(osqp_solve(m_workspace.get()));
+#endif
 }
 
 const Eigen::Matrix<c_float, -1, 1> &OsqpEigen::Solver::getSolution()
 {
     // copy data from an array to Eigen vector
-    c_float* solution = m_workspace->solution->x;
-    m_solution = Eigen::Map<Eigen::Matrix<c_float, -1, 1>>(solution, m_workspace->data->n, 1);
+    c_float* solution = getOSQPSolution()->x;
+    m_solution = Eigen::Map<Eigen::Matrix<c_float, -1, 1>>(solution, getData()->n, 1);
 
     return m_solution;
 }
@@ -177,8 +207,8 @@ const Eigen::Matrix<c_float, -1, 1> &OsqpEigen::Solver::getSolution()
 const Eigen::Matrix<c_float, -1, 1> &OsqpEigen::Solver::getDualSolution()
 {
     // copy data from an array to Eigen vector
-    c_float* solution = m_workspace->solution->y;
-    m_dualSolution = Eigen::Map< Eigen::Matrix<c_float, -1, 1>>(solution, m_workspace->data->m, 1);
+    c_float* solution = getOSQPSolution()->y;
+    m_dualSolution = Eigen::Map< Eigen::Matrix<c_float, -1, 1>>(solution, getData()->m, 1);
 
     return m_dualSolution;
 }
@@ -193,10 +223,17 @@ const std::unique_ptr<OsqpEigen::Data>& OsqpEigen::Solver::data() const
     return m_data;
 }
 
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+const std::unique_ptr<OSQPSolver, std::function<void(OSQPSolver *)>> & OsqpEigen::Solver::solver() const
+{
+    return m_solver;
+}
+#else
 const std::unique_ptr<OSQPWorkspace, std::function<void(OSQPWorkspace *)>>& OsqpEigen::Solver::workspace() const
 {
     return m_workspace;
 }
+#endif
 
 bool OsqpEigen::Solver::updateGradient(const Eigen::Ref<const Eigen::Matrix<c_float, Eigen::Dynamic, 1>>& gradient)
 {
@@ -207,14 +244,18 @@ bool OsqpEigen::Solver::updateGradient(const Eigen::Ref<const Eigen::Matrix<c_fl
     }
 
     // check if the dimension of the gradient is correct
-    if(gradient.rows() != m_workspace->data->n){
+    if(gradient.rows() != getData()->n){
         debugStream() << "[OsqpEigen::Solver::updateGradient] The size of the gradient must be equal to the number of the variables."
                   << std::endl;
         return false;
     }
 
     // update the gradient vector
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+    if(osqp_update_data_vec(m_solver.get(), gradient.data(), nullptr, nullptr)){
+#else
     if(osqp_update_lin_cost(m_workspace.get(), gradient.data())){
+#endif
         debugStream() << "[OsqpEigen::Solver::updateGradient] Error when the update gradient is called."
                   << std::endl;
         return false;
@@ -231,14 +272,18 @@ bool OsqpEigen::Solver::updateLowerBound(const Eigen::Ref<const Eigen::Matrix<c_
     }
 
     // check if the dimension of the lowerBound vector is correct
-    if(lowerBound.rows() != m_workspace->data->m){
+    if(lowerBound.rows() != getData()->m){
         debugStream() << "[OsqpEigen::Solver::updateLowerBound] The size of the lower bound must be equal to the number of the variables."
                   << std::endl;
         return false;
     }
 
     // update the lower bound vector
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+    if(osqp_update_data_vec(m_solver.get(), nullptr, lowerBound.data(), nullptr)){
+#else
     if(osqp_update_lower_bound(m_workspace.get(), lowerBound.data())){
+#endif
         debugStream() << "[OsqpEigen::Solver::updateLowerBound] Error when the update lower bound is called."
                   << std::endl;
         return false;
@@ -256,14 +301,18 @@ bool OsqpEigen::Solver::updateUpperBound(const Eigen::Ref<const Eigen::Matrix<c_
     }
 
     // check if the dimension of the upperBound vector is correct
-    if(upperBound.rows() != m_workspace->data->m){
+    if(upperBound.rows() != getData()->m){
         debugStream() << "[OsqpEigen::Solver::updateUpperBound] The size of the upper bound must be equal to the number of the variables."
                   << std::endl;
         return false;
     }
 
     // update the upper bound vector
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+    if(osqp_update_data_vec(m_solver.get(), nullptr, nullptr, upperBound.data())){
+#else
     if(osqp_update_upper_bound(m_workspace.get(), upperBound.data())){
+#endif
         debugStream() << "[OsqpEigen::Solver::updateUpperBound] Error when the update upper bound is called."
                   << std::endl;
         return false;
@@ -281,21 +330,25 @@ bool OsqpEigen::Solver::updateBounds(const Eigen::Ref<const Eigen::Matrix<c_floa
     }
 
     // check if the dimension of the upperBound vector is correct
-    if(upperBound.rows() != m_workspace->data->m){
+    if(upperBound.rows() != getData()->m){
         debugStream() << "[OsqpEigen::Solver::updateBounds] The size of the upper bound must be equal to the number of the variables."
                   << std::endl;
         return false;
     }
 
     // check if the dimension of the lowerBound vector is correct
-    if(lowerBound.rows() != m_workspace->data->m){
+    if(lowerBound.rows() != getData()->m){
         debugStream() << "[OsqpEigen::Solver::updateBounds] The size of the lower bound must be equal to the number of the variables."
                   << std::endl;
         return false;
     }
 
     // update lower and upper constraints
+#ifdef OSQP_EIGEN_OSQP_IS_V1
+    if(osqp_update_data_vec(m_solver.get(), nullptr, lowerBound.data(), upperBound.data())){
+#else
     if(osqp_update_bounds(m_workspace.get(), lowerBound.data(), upperBound.data())){
+#endif
         debugStream() << "[OsqpEigen::Solver::updateBounds] Error when the update bounds is called."
                   << std::endl;
         return false;


### PR DESCRIPTION
This PR updates osqp-eigen to be compatible with OSQP v1.0.0 (currently in beta). I have kept the API of osqp-eigen (almost) identical

The following things are known to not work (and afaik cannot be done with OSQP v1.0.0)
- `bool OsqpEigen::Solver::getPrimalVariable(Eigen::Matrix<T, n, 1> &dualVariable)` and `bool OsqpEigen::Solver::getDualVariable(Eigen::Matrix<T, m, 1> &dualVariable)` return the solution held in the solution rather than the values in the workspace (which are not accessible anymore)
- `bool OsqpEigen::Solver::clearSolverVariables()` is a no-op since workspace is opaque now

Otherwise I can at least confirm the unit tests pass but I haven't tried much more.