### PR TITLE
Update catch2 to v2.13.9 and osqp to v0.6.3 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  osqp_TAG: v0.6.2
+  osqp_TAG: v0.6.3
   vcpkg_robotology_TAG: v0.0.3
-  Catch2_TAG: v2.12.1
+  Catch2_TAG: v2.13.9
   # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg  
   VCPKG_INSTALLATION_ROOT: C:\robotology\vcpkg
 


### PR DESCRIPTION
Fix https://github.com/robotology/osqp-eigen/issues/132 .