### PR TITLE
Fix missing #include <cassert>

### DIFF
--- a/include/OsqpEigen/SparseMatrixHelper.tpp
+++ b/include/OsqpEigen/SparseMatrixHelper.tpp
@@ -5,6 +5,8 @@
  * @date 2018
  */
 
+#include <cassert>
+
 #include <OsqpEigen/Debug.hpp>
 
 template<typename Derived>


### PR DESCRIPTION
Assert is used in SparseMatrixHelper.tpp, so the relative header should be included. Probably it was working with old version of GCC/libstdc++ due to some transitive include in the standard library.

Fix https://github.com/robotology/osqp-eigen/issues/141 .