### PR TITLE
Do not run try_compile if OSQP_IS_V1 is already defined

### DIFF
--- a/cmake/OsqpEigenDependencies.cmake
+++ b/cmake/OsqpEigenDependencies.cmake
@@ -11,7 +11,9 @@ include(OsqpEigenFindOptionalDependencies)
 ## Required Dependencies
 find_package(Eigen3 3.2.92 REQUIRED)
 find_package(osqp REQUIRED)
-try_compile(OSQP_IS_V1 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp.cpp LINK_LIBRARIES osqp::osqp)
+if(NOT DEFINED OSQP_IS_V1)
+  try_compile(OSQP_IS_V1 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp.cpp LINK_LIBRARIES osqp::osqp)
+endif()
 
 #---------------------------------------------
 ## Optional Dependencies


### PR DESCRIPTION
In some corner cases (see https://github.com/robotology/robotology-superbuild/issues/1451) `try_compile`  is creating problems, so it is convenient not to call it at all by setting `OSQP_IS_V1` as a CMake option if the OSQP version used is known.

fyi @gergondet 