### PR TITLE
Replace csc_set_data with OSQPCscMatrix_new

### DIFF
--- a/include/OsqpEigen/Compat.hpp
+++ b/include/OsqpEigen/Compat.hpp
@@ -49,23 +49,15 @@ inline OSQPCscMatrix* spalloc(OSQPInt m,
                               OSQPInt n,
                               OSQPInt nzmax)
 {
-    OSQPCscMatrix* M = static_cast<OSQPCscMatrix*>(calloc(1, sizeof(OSQPCscMatrix))); /* allocate the OSQPCscMatrix struct */
-    if (!M)
-    {
-        return static_cast<OSQPCscMatrix*>(OSQP_NULL);
-    }
-
     OSQPInt* M_p = static_cast<OSQPInt*>(calloc(n + 1, sizeof(OSQPInt)));
     if (!M_p)
     {
-        free(M);
         return static_cast<OSQPCscMatrix*>(OSQP_NULL);
     }
 
     OSQPInt* M_i = static_cast<OSQPInt*>(calloc(nzmax,  sizeof(OSQPInt)));
     if (!M_i)
     {
-        free(M);
         free(M_p);
         return static_cast<OSQPCscMatrix*>(OSQP_NULL);
     }
@@ -73,7 +65,6 @@ inline OSQPCscMatrix* spalloc(OSQPInt m,
     OSQPFloat* M_x = static_cast<OSQPFloat*>(calloc(nzmax,  sizeof(OSQPFloat)));
     if (!M_x)
     {
-        free(M);
         free(M_p);
         free(M_i);
         return static_cast<OSQPCscMatrix*>(OSQP_NULL);
@@ -86,7 +77,14 @@ inline OSQPCscMatrix* spalloc(OSQPInt m,
         M_nnz = nzmax;
     }
 
-    csc_set_data(M, m, n, M_nnz, M_x, M_i, M_p);
+    OSQPCscMatrix* M = OSQPCscMatrix_new(m, n, M_nnz, M_x, M_i, M_p);
+    if (!M)
+    {
+        free(M_p);
+        free(M_i);
+        free(M_x);
+        return static_cast<OSQPCscMatrix*>(OSQP_NULL);
+    }
 
     return M;
 }


### PR DESCRIPTION
With newest commit from osqp https://github.com/osqp/osqp/commit/4f27eb5152da005cb5f1b294c8b5282feff8edec.
The function `csc_set_data` is deprecated. The new approach is to use `OSQPCscMatrix_new`