### PR TITLE
Support building v0.6.3, v1.0.0.beta1 and v1.0.0 and bump version to 0.10.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  osqp_TAG: ${{ matrix.osqp_TAG }}
   vcpkg_robotology_TAG: v0.0.3
   Catch2_TAG: v3.8.0
   # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg  
@@ -18,7 +17,7 @@ env:
 # Test with different operating systems
 jobs:
   build:
-    name: '[${{ matrix.os }}@${{ matrix.build_type }}] [float:${{ matrix.float }}]'
+    name: '[${{ matrix.os }}@${{ matrix.build_type }}@${{ matrix.osqp_TAG }}] [float:${{ matrix.float }}]'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -76,7 +75,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/install/deps
-        key: source-deps-${{ runner.os }}-${{ matrix.build_type }}-use-float-${{ matrix.float }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-osqp-${{ env.osqp_TAG }}-catch2-${{ env.Catch2_TAG }}
+        key: source-deps-${{ runner.os }}-${{ matrix.build_type }}-use-float-${{ matrix.float }}-vcpkg-robotology-${{ env.vcpkg_robotology_TAG }}-osqp-${{ matrix.osqp_TAG }}-catch2-${{ env.Catch2_TAG }}
 
     - name: Source-based Dependencies [Windows]
       if: steps.cache-source-deps.outputs.cache-hit != 'true' && matrix.os == 'windows-latest'
@@ -84,7 +83,7 @@ jobs:
       run: |
         # osqp
         cd ${GITHUB_WORKSPACE}
-        git clone --recursive -b ${osqp_TAG} https://github.com/oxfordcontrol/osqp
+        git clone --recursive -b ${{ matrix.osqp_TAG }} https://github.com/oxfordcontrol/osqp
         cd osqp
         mkdir -p build
         cd build
@@ -100,7 +99,7 @@ jobs:
       run: |
         # osqp
         cd ${GITHUB_WORKSPACE}
-        git clone --recursive -b ${osqp_TAG} https://github.com/oxfordcontrol/osqp
+        git clone --recursive -b ${{ matrix.osqp_TAG }} https://github.com/oxfordcontrol/osqp
         cd osqp
         mkdir -p build
         cd build
@@ -144,17 +143,6 @@ jobs:
               -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
               -DBUILD_TESTING:BOOL=ON \
               -DOSQPEIGEN_RUN_Valgrind_tests:BOOL=ON ..
-
-    - name: Configure [macOS]
-      if: matrix.os == 'macOS-latest'
-      shell: bash
-      run: |
-        mkdir -p build
-        cd build
-        cmake -DCMAKE_PREFIX_PATH=${GITHUB_WORKSPACE}/install/deps \
-              -DCMAKE_INSTALL_PREFIX=${GITHUB_WORKSPACE}/install \
-              -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-              -DBUILD_TESTING:BOOL=ON ..
 
     - name: Build
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
   - cron:  '0 2 * * *'
 
 env:
-  osqp_TAG: v0.6.3
+  osqp_TAG: ${{ matrix.osqp_TAG }}
   vcpkg_robotology_TAG: v0.0.3
   Catch2_TAG: v3.8.0
   # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg  
@@ -24,6 +24,7 @@ jobs:
       matrix:
         build_type: [Debug, Release]
         os: [ubuntu-latest, windows-latest]
+        osqp_TAG: ["v0.6.3", "v1.0.0.beta1", "v1.0.0"]
         float: [ON, OFF]
       fail-fast: false
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,9 @@ target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC osqp::osqp Eigen3::Eigen)
 if(OSQP_IS_V1)
   target_compile_definitions(${LIBRARY_TARGET_NAME} PUBLIC OSQP_EIGEN_OSQP_IS_V1)
 endif()
+if(OSQP_IS_V1_FINAL)
+  target_compile_definitions(${LIBRARY_TARGET_NAME} PUBLIC OSQP_EIGEN_OSQP_IS_V1_FINAL)
+endif()
 
 add_library(OsqpEigen::OsqpEigen ALIAS OsqpEigen)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CopyPolicy: Released under the terms of the BSD 3-clause license
 
 # Set cmake minimum version
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.30)
 
 # Extract version numbers from package.xml
 # Based on code by DART (BSD-2-license)

--- a/cmake/OsqpEigenDependencies.cmake
+++ b/cmake/OsqpEigenDependencies.cmake
@@ -11,9 +11,17 @@ include(OsqpEigenFindOptionalDependencies)
 ## Required Dependencies
 find_package(Eigen3 3.2.92 REQUIRED)
 find_package(osqp REQUIRED)
+
+# OSQP_IS_V1 (and OSQP_EIGEN_OSQP_IS_V1) is defined for v1.0.0.beta1 and v1.0.0 (and later)
 if(NOT DEFINED OSQP_IS_V1)
-  try_compile(OSQP_IS_V1 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp.cpp LINK_LIBRARIES osqp::osqp)
+  try_compile(OSQP_IS_V1 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1.cpp LINK_LIBRARIES osqp::osqp)
 endif()
+
+# OSQP_IS_V1 (and OSQP_EIGEN_OSQP_IS_V1) is defined only for v1.0.0 (and later)
+if(NOT DEFINED OSQP_IS_V1_FINAL)
+  try_compile(OSQP_IS_V1_FINAL ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1-final.cpp LINK_LIBRARIES osqp::osqp)
+endif()
+
 
 #---------------------------------------------
 ## Optional Dependencies

--- a/cmake/try-osqp-v1-final.cpp
+++ b/cmake/try-osqp-v1-final.cpp
@@ -1,0 +1,8 @@
+#include <osqp_api_functions.h>
+
+int main()
+{
+  // This function is only available in OSQP >= 1.0.0
+  OSQPCscMatrix_set_data(nullptr, 0, 0, 0, nullptr, 0, 0);
+  return 0;
+}

--- a/cmake/try-osqp-v1.cpp
+++ b/cmake/try-osqp-v1.cpp
@@ -1,4 +1,4 @@
-// This file is only available on OSQP >= 1.0.0
+// This file is only available on OSQP >= 1.0.0.beta1
 #include <osqp_api_functions.h>
 
 int main()

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = osqp-eigen
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 0.9.0
+PROJECT_NUMBER         = 0.10.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/OsqpEigen/Compat.hpp
+++ b/include/OsqpEigen/Compat.hpp
@@ -86,7 +86,13 @@ inline OSQPCscMatrix* spalloc(OSQPInt m,
         M_nnz = nzmax;
     }
 
-    csc_set_data(M, m, n, M_nnz, M_x, M_i, M_p);
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
+#define OSQPEigen_OSQPCscMatrix_set_data OSQPCscMatrix_set_data
+#else
+#define OSQPEigen_OSQPCscMatrix_set_data csc_set_data
+#endif
+
+    OSQPEigen_OSQPCscMatrix_set_data(M, m, n, M_nnz, M_x, M_i, M_p);
 
     return M;
 }

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>osqp-eigen</name>
-  <version>0.9.0</version>
+  <version>0.10.0</version>
   <description>Simple Eigen-C++ wrapper for OSQP library</description>
   <maintainer email="tbd@tbd.tbd">tbd</maintainer>
 


### PR DESCRIPTION
For avoiding problems in the transition from osqp v0.6.3 to v1.0.0, I would like to make a osqp-eigen release that is compatible with all recent osqp versions. Once that is done, we can drop 0.6.3 support.

Fix https://github.com/robotology/osqp-eigen/issues/188 .
Fix https://github.com/robotology/osqp-eigen/pull/186 .
