### PR TITLE
Fix definition of OsqpEigen::Status::TimeLimitReached in osqp >= 1

### DIFF
--- a/include/OsqpEigen/Constants.hpp
+++ b/include/OsqpEigen/Constants.hpp
@@ -30,7 +30,7 @@ enum class Status : int
     PrimalInfeasible = OSQP_PRIMAL_INFEASIBLE,
     DualInfeasible = OSQP_DUAL_INFEASIBLE,
     Sigint = OSQP_SIGINT,
-#ifdef PROFILING
+#if defined(PROFILING) || defined(OSQP_EIGEN_OSQP_IS_V1)
     TimeLimitReached = OSQP_TIME_LIMIT_REACHED,
 #endif // ifdef PROFILING
     NonCvx = OSQP_NON_CVX,


### PR DESCRIPTION
In osqp 0.6, the `OSQP_TIME_LIMIT_REACHED` macro is only defined if the `PROFILING` macro is defined by the osqp configuration, see https://github.com/osqp/osqp/blob/v0.6.3/include/constants.h#L25-L27, and so also `OsqpEigen::Status::TimeLimitReached` is only defined if `PROFILING` is defined. 

From osqp 1.0.0beta0 instead, the `OSQP_TIME_LIMIT_REACHED` macro is always defined, see https://github.com/osqp/osqp/blob/v1.0.0.beta0/include/public/osqp_api_constants.h#L36 .

This PR ensures that when using osqp 1.0.0beta0 or later, the `OsqpEigen::Status::TimeLimitReached` is always defined, fixing downstream errors such as https://github.com/conda-forge/qpsolvers-eigen-feedstock/pull/5#issuecomment-2781403658 .