### PR TITLE
Add duality gap termination check configuration

### DIFF
--- a/include/OsqpEigen/Settings.hpp
+++ b/include/OsqpEigen/Settings.hpp
@@ -184,6 +184,12 @@ public:
     void setCheckTermination(const int checkTermination);
 
     /**
+     * Set check duality gap termination criteria.
+     * @param checkDualGap If true, duality gap checking is enabled.
+     */
+    void setCheckDualGap(const bool checkDualGap);
+
+    /**
      * Set warm start.
      * @param warmStart if true the warm start is set.
      */

--- a/include/OsqpEigen/Settings.hpp
+++ b/include/OsqpEigen/Settings.hpp
@@ -183,11 +183,13 @@ public:
      */
     void setCheckTermination(const int checkTermination);
 
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
     /**
      * Set check duality gap termination criteria.
      * @param checkDualGap If true, duality gap checking is enabled.
      */
     void setCheckDualGap(const bool checkDualGap);
+#endif
 
     /**
      * Set warm start.

--- a/include/OsqpEigen/Settings.hpp
+++ b/include/OsqpEigen/Settings.hpp
@@ -183,13 +183,11 @@ public:
      */
     void setCheckTermination(const int checkTermination);
 
-#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
     /**
      * Set check duality gap termination criteria.
      * @param checkDualGap If true, duality gap checking is enabled.
      */
     void setCheckDualGap(const bool checkDualGap);
-#endif
 
     /**
      * Set warm start.

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -197,12 +197,15 @@ void OsqpEigen::Settings::setCheckTermination(const int checkTermination)
     m_settings->check_termination = (c_int)checkTermination;
 }
 
-#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
 void OsqpEigen::Settings::setCheckDualGap(const bool checkDualGap)
 {
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
     m_settings->check_dualgap = (c_int)checkDualGap;
-}
+#else
+    debugStream() << "[OsqpEigen::Settings::setCheckDualGap] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
+    unused(checkDualGap);
 #endif
+}
 
 void OsqpEigen::Settings::setWarmStart(const bool warmStart)
 {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -197,10 +197,12 @@ void OsqpEigen::Settings::setCheckTermination(const int checkTermination)
     m_settings->check_termination = (c_int)checkTermination;
 }
 
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
 void OsqpEigen::Settings::setCheckDualGap(const bool checkDualGap)
 {
     m_settings->check_dualgap = (c_int)checkDualGap;
 }
+#endif
 
 void OsqpEigen::Settings::setWarmStart(const bool warmStart)
 {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -197,6 +197,11 @@ void OsqpEigen::Settings::setCheckTermination(const int checkTermination)
     m_settings->check_termination = (c_int)checkTermination;
 }
 
+void OsqpEigen::Settings::setCheckDualGap(const bool checkDualGap)
+{
+    m_settings->check_dualgap = (c_int)checkDualGap;
+}
+
 void OsqpEigen::Settings::setWarmStart(const bool warmStart)
 {
 #ifdef OSQP_EIGEN_OSQP_IS_V1


### PR DESCRIPTION
Add a method to configure the duality gap termination check option added in OSQP v1.0.0.