### PR TITLE
Select OSQP link target from `BUILD_SHARED_LIBS`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,8 @@ target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CM
 
 ADD_WARNINGS_CONFIGURATION_TO_TARGETS(PRIVATE TARGETS ${LIBRARY_TARGET_NAME})
 
-target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC osqp::osqp Eigen3::Eigen)
+target_link_libraries(${LIBRARY_TARGET_NAME}
+  PUBLIC $<IF:$<BOOL:${BUILD_SHARED_LIBS}>,osqp::osqp,osqp::osqpstatic> Eigen3::Eigen)
 if(OSQP_IS_V1)
   target_compile_definitions(${LIBRARY_TARGET_NAME} PUBLIC OSQP_EIGEN_OSQP_IS_V1)
 endif()

--- a/cmake/OsqpEigenDependencies.cmake
+++ b/cmake/OsqpEigenDependencies.cmake
@@ -12,14 +12,20 @@ include(OsqpEigenFindOptionalDependencies)
 find_package(Eigen3 3.2.92 REQUIRED)
 find_package(osqp REQUIRED)
 
+if(BUILD_SHARED_LIBS)
+  set(OSQP_LIB osqp::osqp)
+else()
+  set(OSQP_LIB osqp::osqpstatic)
+endif()
+
 # OSQP_IS_V1 (and OSQP_EIGEN_OSQP_IS_V1) is defined for v1.0.0.beta1 and v1.0.0 (and later)
 if(NOT DEFINED OSQP_IS_V1)
-  try_compile(OSQP_IS_V1 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1.cpp LINK_LIBRARIES osqp::osqp)
+  try_compile(OSQP_IS_V1 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1.cpp LINK_LIBRARIES ${OSQP_LIB})
 endif()
 
 # OSQP_IS_V1 (and OSQP_EIGEN_OSQP_IS_V1) is defined only for v1.0.0 (and later)
 if(NOT DEFINED OSQP_IS_V1_FINAL)
-  try_compile(OSQP_IS_V1_FINAL ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1-final.cpp LINK_LIBRARIES osqp::osqp)
+  try_compile(OSQP_IS_V1_FINAL ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1-final.cpp LINK_LIBRARIES ${OSQP_LIB})
 endif()
 
 


### PR DESCRIPTION
Select the appropriate OSQP link target based on the configured value of `BUILD_SHARED_LIBS`

If `BUILD_SHARED_LIBS` is enabled, then `OsqpEigen` will link against `osqp::osqp`.  Otherwise, it will link against `osqp::osqpstatic`.

Resolves #196 (proposed solution 1).

## Tags

@traversaro 