### PR TITLE
Select OSQP link target from `OSQP_EIGEN_LINK_OSQP_SHARED` flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,8 @@ include(CTest)
 
 option(OSQP_EIGEN_DEBUG_OUTPUT "Print debug error messages to cerr" ON)
 
+option(OSQP_EIGEN_LINK_OSQP_SHARED "Link OSQP as a shared library as opposed to a static library" ${BUILD_SHARED_LIBS})
+
 # Check OsqpEigen dependencies, find necessary libraries.
 include(OsqpEigenDependencies)
 
@@ -112,7 +114,8 @@ target_include_directories(${LIBRARY_TARGET_NAME} PUBLIC "$<BUILD_INTERFACE:${CM
 
 ADD_WARNINGS_CONFIGURATION_TO_TARGETS(PRIVATE TARGETS ${LIBRARY_TARGET_NAME})
 
-target_link_libraries(${LIBRARY_TARGET_NAME} PUBLIC osqp::osqp Eigen3::Eigen)
+target_link_libraries(${LIBRARY_TARGET_NAME}
+  PUBLIC $<IF:$<BOOL:${OSQP_EIGEN_LINK_OSQP_SHARED}>,osqp::osqp,osqp::osqpstatic> Eigen3::Eigen)
 if(OSQP_IS_V1)
   target_compile_definitions(${LIBRARY_TARGET_NAME} PUBLIC OSQP_EIGEN_OSQP_IS_V1)
 endif()

--- a/cmake/OsqpEigenDependencies.cmake
+++ b/cmake/OsqpEigenDependencies.cmake
@@ -12,14 +12,20 @@ include(OsqpEigenFindOptionalDependencies)
 find_package(Eigen3 3.2.92 REQUIRED)
 find_package(osqp REQUIRED)
 
+if(OSQP_EIGEN_LINK_OSQP_SHARED)
+  set(OSQP_LIB osqp::osqp)
+else()
+  set(OSQP_LIB osqp::osqpstatic)
+endif()
+
 # OSQP_IS_V1 (and OSQP_EIGEN_OSQP_IS_V1) is defined for v1.0.0.beta1 and v1.0.0 (and later)
 if(NOT DEFINED OSQP_IS_V1)
-  try_compile(OSQP_IS_V1 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1.cpp LINK_LIBRARIES osqp::osqp)
+  try_compile(OSQP_IS_V1 ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1.cpp LINK_LIBRARIES ${OSQP_LIB})
 endif()
 
 # OSQP_IS_V1 (and OSQP_EIGEN_OSQP_IS_V1) is defined only for v1.0.0 (and later)
 if(NOT DEFINED OSQP_IS_V1_FINAL)
-  try_compile(OSQP_IS_V1_FINAL ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1-final.cpp LINK_LIBRARIES osqp::osqp)
+  try_compile(OSQP_IS_V1_FINAL ${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_CURRENT_LIST_DIR}/try-osqp-v1-final.cpp LINK_LIBRARIES ${OSQP_LIB})
 endif()
 
 


### PR DESCRIPTION
Select the appropriate OSQP link target based on the configured value of the new flag `OSQP_EIGEN_LINK_OSQP_SHARED`.

`OSQP_EIGEN_LINK_OSQP_SHARED` defaults to the value of `BUILD_SHARED_LIBS` of not otherwise specified.  If `OSQP_EIGEN_LINK_OSQP_SHARED` is enabled, then `OsqpEigen` will link against `osqp::osqp`.  Otherwise, it will link against `osqp::osqpstatic`.

Resolves #196 (proposed solution 2).

## Tags

@traversaro 