### PR TITLE
Bump Version to 0.10.3 MODULE.bazel and package.xml

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,6 +1,6 @@
 module(
     name = "osqp-eigen",
-    version = "0.10.0",
+    version = "0.10.3",
     bazel_compatibility = [">=7.2.1"],
     compatibility_level = 1,
 )

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>osqp-eigen</name>
-  <version>0.10.2</version>
+  <version>0.10.3</version>
   <description>Simple Eigen-C++ wrapper for OSQP library</description>
   <maintainer email="tbd@tbd.tbd">tbd</maintainer>
 


### PR DESCRIPTION
It would be great to bump the bazel module version always along with package.xml and the tag.

This PR
Upgrades the version for the bazel module and package.xml
together with this https://github.com/robotology/osqp-eigen/pull/204, this helps downstream users via BCR.

A cleaner BCR integration will be possible afterwards, once tagged.
