### PR TITLE
Expose osqp v1.0.0 specific settings

### DIFF
--- a/include/OsqpEigen/Settings.hpp
+++ b/include/OsqpEigen/Settings.hpp
@@ -202,6 +202,54 @@ public:
     void setTimeLimit(const double timeLimit);
 
     /**
+     * Enable allocation of OSQP solution arrays during setup.
+     * @param allocateSolution if true allocate solution, otherwise allocate on first solve.
+     */
+    void setAllocateSolution(const bool allocateSolution);
+
+    /**
+     * Set maximum iterations for the CG solver (indirect linsys solver).
+     * @param cgMaxIter max number of CG iterations.
+     */
+    void setCgMaxIter(const int cgMaxIter);
+
+    /**
+     * Set the CG preconditioner type.
+     * @param cgPrecond preconditioner type.
+     */
+    void setCgPrecond(const int cgPrecond);
+
+    /**
+     * Set the CG tolerance fraction.
+     * @param cgTolFraction tolerance fraction.
+     */
+    void setCgTolFraction(const double cgTolFraction);
+
+    /**
+     * Set the CG tolerance reduction factor.
+     * @param cgTolReduction tolerance reduction factor.
+     */
+    void setCgTolReduction(const double cgTolReduction);
+
+    /**
+     * Select computation device.
+     * @param device device id/type.
+     */
+    void setDevice(const int device);
+
+    /**
+     * Set profiler verbosity level.
+     * @param level profiler level.
+     */
+    void setProfilerLevel(const int level);
+
+    /**
+     * Configure whether rho is a vector.
+     * @param rhoIsVec if true use vector rho.
+     */
+    void setRhoIsVec(const bool rhoIsVec);
+
+    /**
      * Get a pointer to Settings struct.
      * @return a const pointer to OSQPSettings struct.
      */

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -226,6 +226,91 @@ void OsqpEigen::Settings::setTimeLimit(const double timeLimit)
 #endif
 }
 
+void OsqpEigen::Settings::setAllocateSolution(const bool allocateSolution)
+{
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
+    m_settings->allocate_solution = static_cast<decltype(m_settings->allocate_solution)>(allocateSolution);
+#else
+    debugStream() << "[OsqpEigen::Settings::setAllocateSolution] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
+    unused(allocateSolution);
+#endif
+}
+
+void OsqpEigen::Settings::setCgMaxIter(const int cgMaxIter)
+{
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
+    m_settings->cg_max_iter = static_cast<decltype(m_settings->cg_max_iter)>(cgMaxIter);
+#else
+    debugStream() << "[OsqpEigen::Settings::setCgMaxIter] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
+    unused(cgMaxIter);
+#endif
+}
+
+void OsqpEigen::Settings::setCgPrecond(const int cgPrecond)
+{
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
+    m_settings->cg_precond = static_cast<decltype(m_settings->cg_precond)>(cgPrecond);
+#else
+    debugStream() << "[OsqpEigen::Settings::setCgPrecond] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
+    unused(cgPrecond);
+#endif
+}
+
+void OsqpEigen::Settings::setCgTolFraction(const double cgTolFraction)
+{
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
+    m_settings->cg_tol_fraction = static_cast<decltype(m_settings->cg_tol_fraction)>(cgTolFraction);
+#else
+    debugStream() << "[OsqpEigen::Settings::setCgTolFraction] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
+    unused(cgTolFraction);
+#endif
+}
+
+void OsqpEigen::Settings::setCgTolReduction(const double cgTolReduction)
+{
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
+    m_settings->cg_tol_reduction = static_cast<decltype(m_settings->cg_tol_reduction)>(cgTolReduction);
+#else
+    debugStream() << "[OsqpEigen::Settings::setCgTolReduction] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
+    unused(cgTolReduction);
+#endif
+}
+
+void OsqpEigen::Settings::setDevice(const int device)
+{
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
+    m_settings->device = static_cast<decltype(m_settings->device)>(device);
+#else
+    debugStream() << "[OsqpEigen::Settings::setDevice] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
+    unused(device);
+#endif
+}
+
+void OsqpEigen::Settings::setProfilerLevel(const int level)
+{
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
+#ifdef PROFILING
+    m_settings->profiler_level = static_cast<decltype(m_settings->profiler_level)>(level);
+#else
+    debugStream() << "[OsqpEigen::Settings::setProfilerLevel] OSPQ has been set without PROFILING, hence this setting is disabled." << std::endl;
+    unused(level);
+#endif
+#else
+    debugStream() << "[OsqpEigen::Settings::setProfilerLevel] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
+    unused(level);
+#endif
+}
+
+void OsqpEigen::Settings::setRhoIsVec(const bool rhoIsVec)
+{
+#ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
+    m_settings->rho_is_vec = static_cast<decltype(m_settings->rho_is_vec)>(rhoIsVec);
+#else
+    debugStream() << "[OsqpEigen::Settings::setRhoIsVec] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
+    unused(rhoIsVec);
+#endif
+}
+
 OSQPSettings *const &OsqpEigen::Settings::getSettings() const
 {
     return m_settings;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -289,12 +289,7 @@ void OsqpEigen::Settings::setDevice(const int device)
 void OsqpEigen::Settings::setProfilerLevel(const int level)
 {
 #ifdef OSQP_EIGEN_OSQP_IS_V1_FINAL
-#ifdef PROFILING
     m_settings->profiler_level = static_cast<decltype(m_settings->profiler_level)>(level);
-#else
-    debugStream() << "[OsqpEigen::Settings::setProfilerLevel] OSPQ has been set without PROFILING, hence this setting is disabled." << std::endl;
-    unused(level);
-#endif
 #else
     debugStream() << "[OsqpEigen::Settings::setProfilerLevel] OSQP version is lower than v1.0.0, this setting is not available." << std::endl;
     unused(level);


### PR DESCRIPTION
Fix https://github.com/robotology/osqp-eigen/issues/213 . All the code was generated in GitHub Copilot with GPT-5 with the prompt:

~~~
Can you please solve this issue: [https://github.com/robotology/osqp-eigen/issues/213](vscode-file://vscode-app/c:/Users/straversaro/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) .

Please make sure:

* That the style of the new setters and getters uses the existing camel case style of C++ methods
* That the project continues to compile on older osqp version in which this settings are not available, using the OSQP_EIGEN_OSQP_IS_V1 and OSQP_EIGEN_OSQP_IS_V1_FINAL macros and appropriate ifdef contions
~~~

and then the correcting prompt:

~~~
Sorry, it seems that I Was wrong, getters are not there, so for consistency with the rest of the codebase and do a minimal PR, please remove getters
~~~

However, it is possible that there are some typo or llm slop.