### PR TITLE
Remove version constraint for Eigen3 package for Eigen3 5.0.0 compatibility

### DIFF
--- a/cmake/OsqpEigenDependencies.cmake
+++ b/cmake/OsqpEigenDependencies.cmake
@@ -11,7 +11,7 @@ include(OsqpEigenFindOptionalDependencies)
 ## but we support manually calling FetchContent for Eigen3 or osqp before FetchContent
 ## is called for OsqpEigen, see https://github.com/robotology/osqp-eigen/issues/210
 if(NOT TARGET Eigen3::Eigen)
-  find_package(Eigen3 3.2.92 REQUIRED)
+  find_package(Eigen3 REQUIRED)
 endif()
 if(NOT TARGET osqp::osqp AND NOT TARGET osqp::osqpstatic)
   find_package(osqp REQUIRED)


### PR DESCRIPTION
Without this fix, configuration against Eigen 5 fails with:

~~~
CMake Error at cmake/OsqpEigenDependencies.cmake:14 (find_package):
  Could not find a configuration file for package "Eigen3" that is compatible
  with requested version "3.2.92".

  The following configuration files were considered but not accepted:

    /home/runner/work/robotology-superbuild/robotology-superbuild/.pixi/envs/default/share/eigen3/cmake/Eigen3Config.cmake, version: 5.0.0

Call Stack (most recent call first):
~~~

see https://gitlab.com/libeigen/eigen/-/issues/2972 for more details. As Eigen 3.3 was released in 2016, I think we are fine in just asking for Eigen without checking the version of it.

xref: https://github.com/conda-forge/eigen-feedstock/pull/47
xref: https://github.com/robotology/robotology-superbuild/issues/1902