### PR TITLE
Clean up OSQP_EIGEN_OSQP_TARGET_TO_LINK handling

### DIFF
--- a/cmake/OsqpEigenDependencies.cmake
+++ b/cmake/OsqpEigenDependencies.cmake
@@ -32,9 +32,6 @@ if(NOT DEFINED OSQP_EIGEN_OSQP_TARGET_TO_LINK)
   else()
     set(OSQP_EIGEN_OSQP_TARGET_TO_LINK osqp::osqp)
   endif()
-
-  # If no global OSQP_EIGEN_OSQP_TARGET_TO_LINK is defined, we make sure that the variable is defined also in the parent scope
-  set(OSQP_EIGEN_OSQP_TARGET_TO_LINK ${OSQP_EIGEN_OSQP_TARGET_TO_LINK} PARENT_SCOPE)
 endif()
 
 # OSQP_IS_V1 (and OSQP_EIGEN_OSQP_IS_V1) is defined for v1.0.0.beta1 and v1.0.0 (and later)


### PR DESCRIPTION
Removed unnecessary setting of OSQP_EIGEN_OSQP_TARGET_TO_LINK in parent scope, removing the warning:

~~~
CMake Warning (dev) at cmake/OsqpEigenDependencies.cmake:37 (set):
  Cannot set "OSQP_EIGEN_OSQP_TARGET_TO_LINK": current scope has no parent.
~~~