### PR TITLE
Fix links after org rename from robotology to gbionics

### DIFF
--- a/.github/workflows/test-pixi.yaml
+++ b/.github/workflows/test-pixi.yaml
@@ -48,7 +48,7 @@ jobs:
         rm pixi.lock
 
     # To use valgrind even with conda/pixi we still need to install libc6-dbg via apt on Debian-based distros
-    # See https://github.com/robotology/osqp-eigen/pull/171#issuecomment-2458149581
+    # See https://github.com/gbionics/osqp-eigen/pull/171#issuecomment-2458149581
     - name: Install libc6-dbg
       if: contains(matrix.os, 'ubuntu')
       run: |

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # osqp-eigen
 
-|  General  | [![c++14](https://img.shields.io/badge/standard-C++14-blue.svg?style=flat&logo=c%2B%2B)](https://isocpp.org) [![License](https://img.shields.io/badge/License-BSD_3--Clause-orange.svg)](https://github.com/robotology/osqp-eigen/blob/master/LICENSE) |
+|  General  | [![c++14](https://img.shields.io/badge/standard-C++14-blue.svg?style=flat&logo=c%2B%2B)](https://isocpp.org) [![License](https://img.shields.io/badge/License-BSD_3--Clause-orange.svg)](https://github.com/gbionics/osqp-eigen/blob/master/LICENSE) |
 | :-------: | :----------------------------------------------------------: |
-| **CI/CD** | [![Codacy Badge](https://app.codacy.com/project/badge/Grade/a18710c10f1c4df19bc2759fd50e9cf5)](https://www.codacy.com/gh/robotology/osqp-eigen/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=robotology/osqp-eigen&amp;utm_campaign=Badge_Grade) [![CI](https://github.com/robotology/osqp-eigen/workflows/C++%20CI%20Workflow/badge.svg)](https://github.com/robotology/osqp-eigen/workflows/C++%20CI%20Workflow/badge.svg) [![Azure](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/osqp-eigen-feedstock?branchName=master)](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=341091&view=results) |
+| **CI/CD** | [![Codacy Badge](https://app.codacy.com/project/badge/Grade/a18710c10f1c4df19bc2759fd50e9cf5)](https://www.codacy.com/gh/gbionics/osqp-eigen/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=gbionics/osqp-eigen&amp;utm_campaign=Badge_Grade) [![CI](https://github.com/gbionics/osqp-eigen/workflows/C++%20CI%20Workflow/badge.svg)](https://github.com/gbionics/osqp-eigen/workflows/C++%20CI%20Workflow/badge.svg) [![Azure](https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/osqp-eigen-feedstock?branchName=master)](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=341091&view=results) |
 | **conda** | [![Conda Recipe](https://img.shields.io/badge/recipe-osqp--eigen-green.svg)](https://anaconda.org/conda-forge/osqp-eigen)  [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/osqp-eigen.svg)](https://anaconda.org/conda-forge/osqp-eigen)  [![Conda Version](https://img.shields.io/conda/vn/conda-forge/osqp-eigen.svg)](https://anaconda.org/conda-forge/osqp-eigen)  [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/osqp-eigen.svg)](https://anaconda.org/conda-forge/osqp-eigen) |
 
 
@@ -10,7 +10,7 @@
 Simple C++ wrapper for [osqp](http://osqp.readthedocs.io/en/latest/index.html) library.
 
 ## 📚 Documentation
-The documentation is available online at the accompanying [website](https://robotology.github.io/osqp-eigen).
+The documentation is available online at the accompanying [website](https://gbionics.github.io/osqp-eigen).
 
 
 ## 📄 Dependences
@@ -29,7 +29,7 @@ conda install -c conda-forge osqp-eigen
 
 1. Clone the repository
    ```
-   git clone https://github.com/robotology/osqp-eigen.git
+   git clone https://github.com/gbionics/osqp-eigen.git
    ```
 2. Build it
    ```
@@ -61,7 +61,7 @@ target_link_libraries(example OsqpEigen::OsqpEigen)
 If you prefer to use the [`bazel`](https://bazel.build/) build system, **osqp-eigen** is available in the Bazel Central Registry, so you can use it following the docs available at [`https://registry.bazel.build/modules/osqp-eigen`](https://registry.bazel.build/modules/osqp-eigen).
 
 ##  🐛 Bug reports and support
-All types of [issues](https://github.com/robotology/osqp-eigen/issues/new) are welcome.
+All types of [issues](https://github.com/gbionics/osqp-eigen/issues/new) are welcome.
 
 
 ## 🧩 Compatibility Policy
@@ -71,4 +71,4 @@ This project tries to avoid removing functionalities in minor releases, while fu
 ## 📝 License
 Materials in this repository are distributed under the following license:
 
-> All software is licensed under the BSD 3-Clause License. See [LICENSE](https://github.com/robotology/osqp-eigen/blob/master/LICENSE) file for details.
+> All software is licensed under the BSD 3-Clause License. See [LICENSE](https://github.com/gbionics/osqp-eigen/blob/master/LICENSE) file for details.

--- a/cmake/OsqpEigenDependencies.cmake
+++ b/cmake/OsqpEigenDependencies.cmake
@@ -9,7 +9,7 @@ include(OsqpEigenFindOptionalDependencies)
 ## Required Dependencies
 ## osqp-eigen does not have any option to call FetchContent for its dependencies,
 ## but we support manually calling FetchContent for Eigen3 or osqp before FetchContent
-## is called for OsqpEigen, see https://github.com/robotology/osqp-eigen/issues/210
+## is called for OsqpEigen, see https://github.com/gbionics/osqp-eigen/issues/210
 if(NOT TARGET Eigen3::Eigen)
   find_package(Eigen3 REQUIRED)
 endif()
@@ -17,7 +17,7 @@ if(NOT TARGET osqp::osqp AND NOT TARGET osqp::osqpstatic)
   find_package(osqp REQUIRED)
 endif()
 
-# Select the osqp target to link, see https://github.com/robotology/osqp-eigen/issues/196
+# Select the osqp target to link, see https://github.com/gbionics/osqp-eigen/issues/196
 # Advanced users can directly (for example package manager mantainers) can set the 
 # OSQP_EIGEN_OSQP_TARGET_TO_LINK variable to explicitly select the osqp cmake imported target to link
 if(NOT DEFINED OSQP_EIGEN_OSQP_TARGET_TO_LINK)

--- a/package.xml
+++ b/package.xml
@@ -7,7 +7,7 @@
 
   <license>BSD</license>
 
-  <url type="website">https://github.com/robotology/osqp-eigen</url>
+  <url type="website">https://github.com/gbionics/osqp-eigen</url>
 
   <build_depend>git</build_depend>
   <!-- The following tags are recommended by REP-136 -->


### PR DESCRIPTION
Fixes #224

This PR updates all links that still referenced the old robotology org to use the new gbionics org, including the documentation URL, clone URL, issue tracker link, and license references.