### PR TITLE
tests/BUILD.bazel: load cc_test from rules_cc (native rule removed in Bazel 9)

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,3 +1,5 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
 _TESTS = [
     "SparseMatrix",
     "QP",


### PR DESCRIPTION
Fixes #222 (partially - the bazel CI failure part)

In Bazel 9, native `cc_*` rules were removed and must be loaded from `@rules_cc//cc:defs.bzl`. The root `BUILD.bazel` already does this for `cc_library`, but `tests/BUILD.bazel` was still using `cc_test` as a native rule, causing:

```
ERROR: package contains errors: tests
_removed_rule_failure at /virtual_builtins_bzl/bazel/exports.bzl:40
```

Fix: add `load("@rules_cc//cc:defs.bzl", "cc_test")` to `tests/BUILD.bazel`.