### PR TITLE
Make package buildable for ROS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,11 +153,8 @@ install_basic_package_files(${PROJECT_NAME}
   NO_CHECK_REQUIRED_COMPONENTS_MACRO
   DEPENDENCIES ${OSQP_EIGEN_EXPORTED_DEPENDENCIES})
 
-# When building in a ROS 2 workspace, install package.xml and register
-# with the ament index so the package is visible to ROS 2 tooling. 
-# Unfortunately, ament_package() cannot be used because it requires
-# PROJECT_NAME to match the package.xml name (osqp_eigen).
-# However, this has the benefit of not needing to call find_package.
+# Install package.xml and register with the ament index 
+# so the package is visible to ROS 2 tooling. 
 install(FILES package.xml DESTINATION share/osqp_eigen)
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen "")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,7 @@ install_basic_package_files(${PROJECT_NAME}
 # with the ament index so the package is visible to ROS 2 tooling. 
 # Unfortunately, ament_package() cannot be used because it requires
 # PROJECT_NAME to match the package.xml name (osqp_eigen).
+# However, this has the benefit of not needing to call find_package.
 install(FILES package.xml DESTINATION share/osqp_eigen)
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen "")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,20 +153,14 @@ install_basic_package_files(${PROJECT_NAME}
   NO_CHECK_REQUIRED_COMPONENTS_MACRO
   DEPENDENCIES ${OSQP_EIGEN_EXPORTED_DEPENDENCIES})
 
-find_package(ament_cmake QUIET)
-if ( ament_cmake_FOUND )
-  # When building in a ROS 2 workspace, install package.xml and register
-  # with the ament index so the package is visible to ROS 2 tooling. 
-  # Unfortunately, ament_package() cannot be used because it requires
-  # PROJECT_NAME to match the package.xml name (osqp_eigen).
-  install(FILES package.xml DESTINATION share/osqp_eigen)
-  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen "")
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen
-    DESTINATION share/ament_index/resource_index/packages)
-else()
-  # Install package.xml to share
-  install(FILES package.xml DESTINATION share/cmake/osqp_eigen)
-endif()
+# When building in a ROS 2 workspace, install package.xml and register
+# with the ament index so the package is visible to ROS 2 tooling. 
+# Unfortunately, ament_package() cannot be used because it requires
+# PROJECT_NAME to match the package.xml name (osqp_eigen).
+install(FILES package.xml DESTINATION share/osqp_eigen)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen "")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen
+  DESTINATION share/ament_index/resource_index/packages)
 
 ## Testing
 include(AddOsqpEigenUnitTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,8 +153,20 @@ install_basic_package_files(${PROJECT_NAME}
   NO_CHECK_REQUIRED_COMPONENTS_MACRO
   DEPENDENCIES ${OSQP_EIGEN_EXPORTED_DEPENDENCIES})
 
-# Install package.xml to share
-install(FILES package.xml DESTINATION share/cmake/osqp-eigen)
+find_package(ament_cmake QUIET)
+if ( ament_cmake_FOUND )
+  # When building in a ROS 2 workspace, install package.xml and register
+  # with the ament index so the package is visible to ROS 2 tooling. 
+  # Unfortunately, ament_package() cannot be used because it requires
+  # PROJECT_NAME to match the package.xml name (osqp_eigen).
+  install(FILES package.xml DESTINATION share/osqp_eigen)
+  file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen "")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/ament_index_marker/osqp_eigen
+    DESTINATION share/ament_index/resource_index/packages)
+else()
+  # Install package.xml to share
+  install(FILES package.xml DESTINATION share/cmake/osqp_eigen)
+endif()
 
 ## Testing
 include(AddOsqpEigenUnitTest)

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="3">
-  <name>osqp-eigen</name>
+  <name>osqp_eigen</name>
   <version>0.11.0</version>
   <description>Simple Eigen-C++ wrapper for OSQP library</description>
   <maintainer email="tbd@tbd.tbd">tbd</maintainer>


### PR DESCRIPTION
I was mostly curious to see if there was a path to get this repo usable on the ROS buildfarm without having to vendor it.

The outcome was:
* A simple conditional on the existence of the `ament_cmake` package which does package exporting... although we couldn't directly use the ament macros because of mismatches between the package name and the library namespace.
* Needed to change the project name in the `package.xml` file because `-` characters are not allowed. Hopefully this doesn't impact non-ROS builds?

After these changes, I could build this project from source using `colcon build` and reference it in downstream packages with:

```cmake
find_package(OsqpEigen REQUIRED)
target_link_libraries(my_library OsqpEigen::OsqpEigen)
```

Anyway, curious to see what maintainers think?