### PR TITLE
Do not set VERSION property target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ env:
   Catch2_TAG: v3.8.0
   # Overwrite the VCPKG_INSTALLATION_ROOT env variable defined by GitHub Actions to point to our vcpkg  
   VCPKG_INSTALLATION_ROOT: C:\robotology\vcpkg
+  # Workaround to test old version of qdldl and osqp
+  CMAKE_POLICY_VERSION_MINIMUM: "3.5"
 
 # Test with different operating systems
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,7 +123,6 @@ endif()
 add_library(OsqpEigen::OsqpEigen ALIAS OsqpEigen)
 
 set_target_properties(${LIBRARY_TARGET_NAME} PROPERTIES
-  VERSION ${PROJECT_VERSION}
   PUBLIC_HEADER "${${LIBRARY_TARGET_NAME}_HDR}")
 
 target_compile_features(${LIBRARY_TARGET_NAME} PUBLIC cxx_std_14)


### PR DESCRIPTION
Perhaps in a confusing way, setting the `VERSION` property actually also sets the `SOVERSION`, and we were setting it down to the patch version, that is not compatible with the compat policy mentioned in https://github.com/gbionics/osqp-eigen#-compatibility-policy .